### PR TITLE
docs: add sovereign architecture, connectors, and roadmap

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,9 +2,10 @@
 
 ## Goal
 
-Consolidate K8s metrics into a sovereign datalake and detect variations
-(anomalies / drift) on time-series using PatchTST, with unified batch and
-streaming processing.
+Consolidate K8s metrics into a datalake and detect variations (anomalies /
+drift) on time-series using PatchTST, with unified batch and streaming
+processing. The design is provider-agnostic — deployment target (managed cloud,
+self-hosted, or sovereign) is a configuration choice, not baked into the core.
 
 ## Core principle
 
@@ -12,32 +13,39 @@ The processing core (windowing → PatchTST inference → variation detection)
 never knows where data comes from or goes to. Sources and sinks are **plugins**
 behind a stable contract. Apache Beam is the engine because the same pipeline
 runs in batch (replay history) and streaming (live ingestion), and is portable
-across runners (DirectRunner for dev, Flink/Spark on-cluster for sovereign prod).
+across runners (DirectRunner for dev, Flink/Spark on-cluster or Dataflow for prod).
 
-## Target flow (sovereign stack)
+## Reference flow
+
+The boxes below are *roles*, each filled by an interchangeable connector. The
+names in parentheses are one possible instantiation; any backend that implements
+the SPI role can be substituted (see [CONNECTORS.md](./CONNECTORS.md)).
 
 ```
 Agents (Prometheus / OTEL)
         │  remote-write
         ▼
-   Grafana Mimir  ◄──── metric blocks ────►  MinIO (S3)
-        │  PromQL query_range                      ▲
-        ▼                                          │
-   Beam / Flink  (windowing)                       │
-        │                                          │
-        ▼                                          │
-   PatchTST inference (forecast ⇄ reconstruction)  │
-        │                                          │
-        ▼                                          │
-   Variation detection                             │
-        │                                          │
-        ├──► Iceberg datalake ────────────────────┘  (same MinIO substrate)
-        ├──► ClickHouse (analytics)
-        └──► KubeVerdict (alerting / verdict)
+   metrics store  ◄──── blocks ────►  object store (S3 API)
+   (e.g. Mimir)                            ▲
+        │  query / pull                    │
+        ▼                                  │
+   Beam runner  (windowing)                │
+   (Direct / Flink / Spark / Dataflow)     │
+        │                                  │
+        ▼                                  │
+   PatchTST inference (forecast ⇄ reconstruction)
+        │                                  │
+        ▼                                  │
+   Variation detection                     │
+        │                                  │
+        ├──► datalake (table format) ──────┘  (same object-store substrate)
+        ├──► analytics store
+        └──► alerting / verdict sink
 ```
 
-MinIO is the single object-storage substrate, backing both Mimir blocks and the
-Iceberg datalake — one storage layer to secure, back up, and keep sovereign.
+A single object store (any S3-compatible backend) can serve as the substrate for
+both the metrics store's blocks and the datalake — one storage layer to secure
+and back up, whichever provider you choose.
 
 ## Detection mechanism
 
@@ -135,20 +143,19 @@ p | src.read() | Window() | RunInference(patchtst) | Detect() | *[s.write() for 
 Adding a connector = dropping one file with `@connector("name")`. The core and
 the pipeline never change. That openness is the point of having N connectors.
 
-## Sovereignty model
+## Deployment is independent of design
 
-Three tiers, to be explicit about what "sovereign" means here:
+The architecture is provider-agnostic: *where* it runs is a deployment choice
+layered on top, not a property of the core or the SPI. The same pipeline runs
+against a managed cloud, a self-hosted OSS stack, or a sovereign/EU provider by
+swapping connector config and the runner flag — no code change. See the
+deployment profiles in [CONNECTORS.md](./CONNECTORS.md).
 
-- **SecNumCloud-qualified** (OVHcloud select offers, Outscale/Dassault, Cloud
-  Temple): French/EU law, immune to extra-territorial reach.
-- **"Trusted cloud" but US tech under license** (S3NS = Thales+Google, Bleu =
-  Capgemini/Orange+Microsoft): excluded if strict immunity is the goal.
-- **Open-source self-hosted** (MinIO, Ceph, ClickHouse, Kafka, Mimir): maximum
-  sovereignty since we control the substrate; the operational debt is ours.
-
-Sovereignty is not only runtime: a data catalog (Nessie/Polaris) and lineage
-(OpenMetadata/DataHub) matter too, because proving *where data lives and who
-accesses it* is part of SecNumCloud / GDPR requirements.
+Each profile carries its own trade-offs (managed convenience vs operational
+debt, jurisdiction/compliance, cost). Sovereignty — e.g. SecNumCloud-qualified
+providers with no extra-territorial exposure, plus catalog/lineage to prove
+*where data lives and who accesses it* — is one such profile, selectable when
+required, never assumed.
 
 See [CONNECTORS.md](./CONNECTORS.md) for the plugin catalog and
 [ROADMAP.md](./ROADMAP.md) for milestones and open decisions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ Agents (Prometheus / OTEL)
    Beam / Flink  (windowing)                       │
         │                                          │
         ▼                                          │
-   PatchTST inference (reconstruction error)       │
+   PatchTST inference (forecast ⇄ reconstruction)  │
         │                                          │
         ▼                                          │
    Variation detection                             │
@@ -41,15 +41,54 @@ Iceberg datalake — one storage layer to secure, back up, and keep sovereign.
 
 ## Detection mechanism
 
-Default: **self-supervised reconstruction error** (`PatchTST_self_supervised`).
-The model reconstructs masked patches; the gap between reconstruction and actual
-value is the variation signal. This needs no labels and gives a clean reactive
-signal. The forecast-plus-residual path remains an alternative (decision D1).
+**Decided (D1): dual detector, regime-switching.** Two signals on one PatchTST
+pipeline, each used where it is reliable:
+
+- **Forecast — anticipation** (`PatchTST_supervised`). In the normal/trending
+  regime the model forecasts the trajectory; a predicted threshold crossing
+  within horizon `h` raises an early **WARN**. This is the "see the wall coming"
+  path, scoped to slow-saturation metrics (disk, memory, quota, latency drift).
+- **Reconstruction — detective** (`PatchTST_self_supervised`). A brutal break
+  pushes the input out-of-distribution, where the forecaster collapses (its
+  predictions become unreliable exactly when needed). Reconstruction error spikes
+  cleanly on OOD input, so at the break the verdict switches to this signal — no
+  waiting for `actual[t+h]`.
+
+**Why both, not one.** It is not a compromise but the technically correct split:
+forecast is accurate pre-break and buys lead time; reconstruction is the clean
+signal during the incident *because* forecast degrades under regime change.
+
+**State machine per `group_id`:**
+
+```
+NORMAL  ──(break: reconstruction error spikes)──►  INCIDENT
+   ▲                                                   │
+   └──────────(recovery: error back to baseline)───────┘
+
+NORMAL   : forecast drives anticipation (early WARN)
+INCIDENT : reconstruction drives the verdict; anticipation suspended (model OOD)
+```
+
+**Design constraint:** anticipation only pays if it is actionable — the horizon
+`h` must be ≤ the remediation time (autoscale / drain / page), otherwise an early
+WARN is cosmetic and detective alone is preferable.
 
 ## Connector SPI — open to N plugins
 
 Connectors are not architecture decisions, they are interchangeable
 implementations of one contract.
+
+**Decided (D4): native multivariate pivot.** A row carries an aligned vector of
+channel values at one timestamp:
+`{group_id: str, ts: int, values: tuple[float], channels: tuple[str], labels: dict}`.
+
+Intentional model mismatch, accepted with eyes open: PatchTST is
+**channel-independent** — it processes each channel as an independent univariate
+sequence with no cross-channel attention. So the grouping buys batching and a
+group-level detection decision, **not** joint modeling of cross-channel
+correlation. The real cost of multivariate — temporal alignment of
+heterogeneous K8s cadences onto a common grid — is paid inside the source
+connector (`connectors/alignment.py`), never in the core.
 
 ```python
 # connectors/base.py
@@ -57,7 +96,7 @@ from abc import ABC, abstractmethod
 import apache_beam as beam
 
 # Pivot schema — the only language the core understands:
-# {series_id: str, ts: int, value: float, labels: dict}
+# {group_id: str, ts: int, values: tuple[float], channels: tuple[str], labels: dict}
 
 class SourceConnector(ABC):
     @abstractmethod

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,115 @@
+# Architecture — Metrics Variation Detection on PatchTST
+
+## Goal
+
+Consolidate K8s metrics into a sovereign datalake and detect variations
+(anomalies / drift) on time-series using PatchTST, with unified batch and
+streaming processing.
+
+## Core principle
+
+The processing core (windowing → PatchTST inference → variation detection)
+never knows where data comes from or goes to. Sources and sinks are **plugins**
+behind a stable contract. Apache Beam is the engine because the same pipeline
+runs in batch (replay history) and streaming (live ingestion), and is portable
+across runners (DirectRunner for dev, Flink/Spark on-cluster for sovereign prod).
+
+## Target flow (sovereign stack)
+
+```
+Agents (Prometheus / OTEL)
+        │  remote-write
+        ▼
+   Grafana Mimir  ◄──── metric blocks ────►  MinIO (S3)
+        │  PromQL query_range                      ▲
+        ▼                                          │
+   Beam / Flink  (windowing)                       │
+        │                                          │
+        ▼                                          │
+   PatchTST inference (reconstruction error)       │
+        │                                          │
+        ▼                                          │
+   Variation detection                             │
+        │                                          │
+        ├──► Iceberg datalake ────────────────────┘  (same MinIO substrate)
+        ├──► ClickHouse (analytics)
+        └──► KubeVerdict (alerting / verdict)
+```
+
+MinIO is the single object-storage substrate, backing both Mimir blocks and the
+Iceberg datalake — one storage layer to secure, back up, and keep sovereign.
+
+## Detection mechanism
+
+Default: **self-supervised reconstruction error** (`PatchTST_self_supervised`).
+The model reconstructs masked patches; the gap between reconstruction and actual
+value is the variation signal. This needs no labels and gives a clean reactive
+signal. The forecast-plus-residual path remains an alternative (decision D1).
+
+## Connector SPI — open to N plugins
+
+Connectors are not architecture decisions, they are interchangeable
+implementations of one contract.
+
+```python
+# connectors/base.py
+from abc import ABC, abstractmethod
+import apache_beam as beam
+
+# Pivot schema — the only language the core understands:
+# {series_id: str, ts: int, value: float, labels: dict}
+
+class SourceConnector(ABC):
+    @abstractmethod
+    def read(self) -> beam.PTransform:   # -> PCollection[PivotRow]
+        ...
+
+class SinkConnector(ABC):
+    @abstractmethod
+    def write(self) -> beam.PTransform:  # PCollection -> writes out
+        ...
+```
+
+```python
+# connectors/registry.py
+_REGISTRY: dict[str, type] = {}
+
+def connector(name: str):
+    def deco(cls):
+        _REGISTRY[name] = cls
+        return cls
+    return deco
+
+def build(name: str, **cfg):
+    return _REGISTRY[name](**cfg)
+```
+
+The pipeline is config-driven and source/sink agnostic:
+
+```python
+src = build(cfg.source.type, **cfg.source.params)
+sinks = [build(s.type, **s.params) for s in cfg.sinks]
+
+p | src.read() | Window() | RunInference(patchtst) | Detect() | *[s.write() for s in sinks]
+```
+
+Adding a connector = dropping one file with `@connector("name")`. The core and
+the pipeline never change. That openness is the point of having N connectors.
+
+## Sovereignty model
+
+Three tiers, to be explicit about what "sovereign" means here:
+
+- **SecNumCloud-qualified** (OVHcloud select offers, Outscale/Dassault, Cloud
+  Temple): French/EU law, immune to extra-territorial reach.
+- **"Trusted cloud" but US tech under license** (S3NS = Thales+Google, Bleu =
+  Capgemini/Orange+Microsoft): excluded if strict immunity is the goal.
+- **Open-source self-hosted** (MinIO, Ceph, ClickHouse, Kafka, Mimir): maximum
+  sovereignty since we control the substrate; the operational debt is ours.
+
+Sovereignty is not only runtime: a data catalog (Nessie/Polaris) and lineage
+(OpenMetadata/DataHub) matter too, because proving *where data lives and who
+accesses it* is part of SecNumCloud / GDPR requirements.
+
+See [CONNECTORS.md](./CONNECTORS.md) for the plugin catalog and
+[ROADMAP.md](./ROADMAP.md) for milestones and open decisions.

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -2,70 +2,85 @@
 
 Connectors implement the SPI defined in [ARCHITECTURE.md](./ARCHITECTURE.md):
 `SourceConnector.read()` and `SinkConnector.write()`, both speaking the pivot
-schema `{series_id, ts, value, labels}`. Each connector is a plugin registered
-with `@connector("name")`; the core never depends on a concrete connector.
+schema `{group_id, ts, values[], channels[], labels}`. Each connector is a plugin
+registered with `@connector("name")`; the core never depends on a concrete
+connector.
 
-The catalog below is oriented toward a sovereign cloud (no US hyperscaler), but
-any connector that satisfies the contract and passes the conformance suite can
-be added.
+**The SPI is provider-agnostic.** A connector is just an implementation of the
+contract — it can target a managed cloud service, a self-hosted OSS system, or a
+sovereign provider. The catalog below is grouped by *function*; within each
+function the backends are interchangeable, and none is privileged. Pick whichever
+fits your environment; the pipeline code does not change.
 
-## Sources
+## Sources — metrics ingestion
 
-| ID  | Plugin | Mechanism | Replaces (GCP) | Sovereignty / Note |
-|-----|--------|-----------|----------------|--------------------|
-| C9a | **Grafana Mimir** | remote-write in + PromQL read | — | OSS (AGPLv3) · blocks on MinIO · multi-tenant, single entry point |
-| C1  | Prometheus PromQL | `query_range` | — | OSS · typically points at Mimir |
-| C2  | OTLP / remote-write | live push | — | OSS, vendor-neutral |
-| C7  | Kafka / Redpanda | streaming bus | PubSub | OSS self-hosted · Redpanda lighter, no ZooKeeper |
-| C8  | NATS JetStream | streaming bus | PubSub | OSS · low footprint, edge-friendly |
-| C10 | VictoriaMetrics | TSDB read/write | — | OSS · compact Thanos/Mimir alternative |
+| ID  | Plugin | Mechanism | Note |
+|-----|--------|-----------|------|
+| C9a | **Grafana Mimir** | remote-write in + PromQL read | multi-tenant, single entry point, blocks on object storage |
+| C1  | Prometheus | PromQL `query_range` | direct scrape target or long-term store front-end |
+| C2  | OTLP / remote-write | live push | vendor-neutral OpenTelemetry |
+| C7  | Kafka / Redpanda | streaming bus | Redpanda lighter, no ZooKeeper |
+| C8  | NATS JetStream | streaming bus | low footprint, edge-friendly |
+| C10 | VictoriaMetrics | TSDB read/write | compact TSDB alternative |
+| C23 | Cloud Pub/Sub / Kinesis | managed streaming bus | managed-cloud option |
 
 ## Sinks — object storage / datalake
 
-| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
-|-----|--------|----------------|--------------------|
-| C11 | **MinIO** | GCS | OSS · S3 API · single storage substrate |
-| C12 | Ceph RGW | GCS | OSS · on-prem at scale |
-| C13 | OVHcloud / Scaleway Object Storage | GCS | SecNumCloud (select offers) · EU |
-| C14 | Outscale OOS | GCS | SecNumCloud · Dassault Systèmes |
+All speak the **S3 API**, so a single connector covers every S3-compatible
+backend; the target is a config/credentials concern, not a code change.
+
+| ID  | Plugin | Backend examples |
+|-----|--------|------------------|
+| C11 | **S3-compatible object store** | AWS S3 · GCS (interop) · Azure Blob · MinIO · Ceph RGW · OVHcloud / Scaleway / Outscale |
 
 ## Sinks — analytics / query
 
-| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
-|-----|--------|----------------|--------------------|
-| C15 | **ClickHouse** | BigQuery | OSS · strong on time-series OLAP |
-| C16 | TimescaleDB / PostgreSQL | BigQuery | OSS · for moderate volume |
-| C17 | Trino / DuckDB | BigQuery | OSS · query-on-lake over Parquet/Iceberg |
+| ID  | Plugin | Note |
+|-----|--------|------|
+| C15 | **ClickHouse** | strong on time-series OLAP |
+| C16 | TimescaleDB / PostgreSQL | for moderate volume |
+| C17 | Trino / DuckDB | query-on-lake over Parquet/Iceberg |
+| C24 | BigQuery / Snowflake / Redshift | managed-cloud warehouses |
 
-## Table format, catalog, governance
+## Table format & catalog
 
-| ID  | Plugin | Role | Sovereignty / Note |
-|-----|--------|------|--------------------|
-| C18 | **Apache Iceberg** (on MinIO) | ACID table format, time-travel | OSS · open datalake |
-| C19 | Nessie / Polaris | versioned "git-for-data" catalog | OSS · table governance |
-| C22 | OpenMetadata / DataHub | lineage, governance | OSS · traceability for SecNumCloud/GDPR |
+| ID  | Plugin | Role |
+|-----|--------|------|
+| C18 | **Apache Iceberg** / Delta | ACID table format, time-travel, open datalake |
+| C19 | Nessie / Polaris | versioned "git-for-data" catalog |
+| C22 | OpenMetadata / DataHub | lineage, governance, traceability |
 
 ## Alerting
 
-| ID  | Plugin | Role | Note |
-|-----|--------|------|------|
-| C6  | **KubeVerdict** | emit verdict + context | in-house |
+| ID  | Plugin | Role |
+|-----|--------|------|
+| C6  | **KubeVerdict** | emit verdict + context (in-house) |
+| C25 | Alertmanager / PagerDuty / Opsgenie | standard alert routing |
 
-## Runners (Beam execution, not connectors but sovereignty-relevant)
+## Runners — execution axis (not connectors)
 
-| ID  | Runner | Replaces (GCP) | Note |
-|-----|--------|----------------|------|
-| C20 | Flink on-K8s | Dataflow | OSS · streaming, the J6 operational debt |
-| C21 | Spark on-K8s | Dataflow | OSS · batch, if Spark already in place |
+Runners are the *other* axis: the Beam pipeline is portable, so the runner is a
+`--runner` flag, not connector code. Listed here only for completeness.
 
-## Recommended sovereign stack
+| Runner | Use |
+|--------|-----|
+| DirectRunner | local dev / test |
+| Flink / Spark on-K8s | self-hosted production |
+| Dataflow | managed-cloud production (GCP) |
+
+## Deployment profiles (examples — none privileged)
+
+The same pipeline runs against different stacks by swapping connector config and
+the runner flag:
 
 ```
-Agents → Mimir (C9a) → Beam/Flink (C20) → MinIO+Iceberg (C11/C18)
-       → ClickHouse (C15) → KubeVerdict (C6)
+Managed cloud (GCP):  Pub/Sub → Dataflow → GCS + BigQuery
+Self-hosted (OSS):    Mimir   → Flink    → MinIO + Iceberg → ClickHouse
+Sovereign (EU):       Mimir   → Flink    → OVH/Outscale S3 → ClickHouse
 ```
 
-All OSS, self-hostable on the K8s cluster, zero US-hyperscaler dependency, and
-migratable to a SecNumCloud provider (C13/C14) without touching pipeline code
-thanks to the shared S3 API. MinIO is the single substrate under both Mimir and
-the Iceberg datalake.
+Sovereignty (SecNumCloud-qualified providers, no US-hyperscaler dependency) is
+**one** such profile — selectable, not assumed. Because the object-storage sink
+speaks the S3 API and the runner is a flag, moving between profiles needs no code
+change. The trade-offs that distinguish profiles (managed vs operational debt,
+jurisdiction, cost) are deployment decisions, independent of the SPI.

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,0 +1,71 @@
+# Connectors — Plugin Catalog
+
+Connectors implement the SPI defined in [ARCHITECTURE.md](./ARCHITECTURE.md):
+`SourceConnector.read()` and `SinkConnector.write()`, both speaking the pivot
+schema `{series_id, ts, value, labels}`. Each connector is a plugin registered
+with `@connector("name")`; the core never depends on a concrete connector.
+
+The catalog below is oriented toward a sovereign cloud (no US hyperscaler), but
+any connector that satisfies the contract and passes the conformance suite can
+be added.
+
+## Sources
+
+| ID  | Plugin | Mechanism | Replaces (GCP) | Sovereignty / Note |
+|-----|--------|-----------|----------------|--------------------|
+| C9a | **Grafana Mimir** | remote-write in + PromQL read | — | OSS (AGPLv3) · blocks on MinIO · multi-tenant, single entry point |
+| C1  | Prometheus PromQL | `query_range` | — | OSS · typically points at Mimir |
+| C2  | OTLP / remote-write | live push | — | OSS, vendor-neutral |
+| C7  | Kafka / Redpanda | streaming bus | PubSub | OSS self-hosted · Redpanda lighter, no ZooKeeper |
+| C8  | NATS JetStream | streaming bus | PubSub | OSS · low footprint, edge-friendly |
+| C10 | VictoriaMetrics | TSDB read/write | — | OSS · compact Thanos/Mimir alternative |
+
+## Sinks — object storage / datalake
+
+| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
+|-----|--------|----------------|--------------------|
+| C11 | **MinIO** | GCS | OSS · S3 API · single storage substrate |
+| C12 | Ceph RGW | GCS | OSS · on-prem at scale |
+| C13 | OVHcloud / Scaleway Object Storage | GCS | SecNumCloud (select offers) · EU |
+| C14 | Outscale OOS | GCS | SecNumCloud · Dassault Systèmes |
+
+## Sinks — analytics / query
+
+| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
+|-----|--------|----------------|--------------------|
+| C15 | **ClickHouse** | BigQuery | OSS · strong on time-series OLAP |
+| C16 | TimescaleDB / PostgreSQL | BigQuery | OSS · for moderate volume |
+| C17 | Trino / DuckDB | BigQuery | OSS · query-on-lake over Parquet/Iceberg |
+
+## Table format, catalog, governance
+
+| ID  | Plugin | Role | Sovereignty / Note |
+|-----|--------|------|--------------------|
+| C18 | **Apache Iceberg** (on MinIO) | ACID table format, time-travel | OSS · open datalake |
+| C19 | Nessie / Polaris | versioned "git-for-data" catalog | OSS · table governance |
+| C22 | OpenMetadata / DataHub | lineage, governance | OSS · traceability for SecNumCloud/GDPR |
+
+## Alerting
+
+| ID  | Plugin | Role | Note |
+|-----|--------|------|------|
+| C6  | **KubeVerdict** | emit verdict + context | in-house |
+
+## Runners (Beam execution, not connectors but sovereignty-relevant)
+
+| ID  | Runner | Replaces (GCP) | Note |
+|-----|--------|----------------|------|
+| C20 | Flink on-K8s | Dataflow | OSS · streaming, the J6 operational debt |
+| C21 | Spark on-K8s | Dataflow | OSS · batch, if Spark already in place |
+
+## Recommended sovereign stack
+
+```
+Agents → Mimir (C9a) → Beam/Flink (C20) → MinIO+Iceberg (C11/C18)
+       → ClickHouse (C15) → KubeVerdict (C6)
+```
+
+All OSS, self-hostable on the K8s cluster, zero US-hyperscaler dependency, and
+migratable to a SecNumCloud provider (C13/C14) without touching pipeline code
+thanks to the shared S3 API. MinIO is the single substrate under both Mimir and
+the Iceberg datalake.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,7 +32,9 @@ real value — before investing in streaming ops.
 Once the SPI (M1.5) is frozen, each connector is a small, parallelizable PR:
 drop a file under `connectors/sources/` or `connectors/sinks/` with
 `@connector("name")` and pass the conformance suite. P0 connectors for the POC:
-**Mimir (C9a)** source and **MinIO/Iceberg (C11/C18)** sink.
+a metrics source (**Mimir, C9a**) and an **object-store + table-format** sink
+(**S3 API + Iceberg, C11/C18** — backend-agnostic). Other backends are added on
+demand, not upfront.
 
 ## Open decisions
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,12 +7,12 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) and [CONNECTORS.md](./CONNECTORS.md).
 
 | Milestone | Deliverable | Priority |
 |-----------|-------------|----------|
-| **M0** | Frozen decisions (D1–D5 below) — gate before any code beyond M2 | 🔴 blocking |
-| **M1** | PatchTST inference module decoupled from the training `Learner`: `predict(window) -> reconstruction`, RevIN normalization, checkpoint loaded once per worker | P0 |
-| **M1.5** | **Connector SPI**: pivot schema + `SourceConnector`/`SinkConnector` contracts + `registry` + contract/conformance test suite | P0 |
+| **M0** | Frozen decisions (D1–D5 below) — gate before any code beyond M2 | ✅ D1/D3/D4 decided |
+| **M1** | PatchTST inference module decoupled from the training `Learner`, exposing **both heads**: `forecast(window)` and `reconstruct(window)`; RevIN normalization, checkpoint loaded once per worker | P0 |
+| **M1.5** | **Connector SPI**: pivot schema + `SourceConnector`/`SinkConnector` contracts + `registry` + contract/conformance test suite — *implemented (PR #2), 100% coverage* | ✅ done |
 | **M2** | Beam batch skeleton on DirectRunner: source → windowing → sink, no model. Validates pivot schema end-to-end (dev/test only, never prod) | P0 |
-| **M3** | PatchTST in the pipeline via `RunInference` with a custom PyTorch `ModelHandler`: per-worker load, batching, device. Output enriched with reconstruction + error | P0 |
-| **M4** | Variation detection: static thresholding first, then adaptive (rolling quantile / MAD) per `series_id`, plus anti-flapping (hysteresis, debounce) | P0 |
+| **M3** | PatchTST in the pipeline via `RunInference` with a custom PyTorch `ModelHandler`: per-worker load, batching, device. Output enriched with **forecast residual + reconstruction error** | P0 |
+| **M4** | **Regime-switching detection** per `group_id` (NORMAL→INCIDENT state machine): forecast anticipation (early WARN, `h ≤ remediation time`) in NORMAL, reconstruction detective verdict in INCIDENT; adaptive thresholds (rolling quantile / MAD), per-channel residual aggregation, anti-flapping | P0 |
 | **M5** | Streaming: same pipeline unbounded — sliding windows, watermarks, late data, triggering | P1 |
 | **M6** | Production runner (Flink on-K8s or Dataflow) + pipeline monitoring (lag, throughput, failures) | P1 |
 | **M7** | KubeVerdict alerting + optional retraining loop back to the datalake | P2 |
@@ -36,12 +36,12 @@ drop a file under `connectors/sources/` or `connectors/sinks/` with
 
 ## Open decisions
 
-| #  | Question | Proposed default |
-|----|----------|------------------|
-| D1 | Detection: reconstruction vs forecast+residual | **Reconstruction** (self-supervised) |
+| #  | Question | Decision |
+|----|----------|----------|
+| D1 | Detection mechanism | ✅ **Both, regime-switching**: forecast (anticipate the wall) in NORMAL, reconstruction (detective) at the break |
 | D2 | Mimir as sole ingress, or Kafka/OTLP in parallel for low-latency live? | TBD |
-| D3 | Plugin discovery: internal registry vs Python entry-points (third-party plugins) | Internal first |
-| D4 | Pivot schema: univariate vs native multivariate (PatchTST channel-independence) | TBD |
+| D3 | Plugin discovery: internal registry vs Python entry-points | ✅ **Internal registry** |
+| D4 | Pivot schema: univariate vs native multivariate | ✅ **Native multivariate** |
 | D5 | Datalake purpose: retraining vs analytics/compliance vs both | TBD |
 
 ## Scope note — SPI vs catalog

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,52 @@
+# Roadmap
+
+Milestones are sequential; the **Connector SPI** is the cross-cutting backbone.
+See [ARCHITECTURE.md](./ARCHITECTURE.md) and [CONNECTORS.md](./CONNECTORS.md).
+
+## Milestones
+
+| Milestone | Deliverable | Priority |
+|-----------|-------------|----------|
+| **M0** | Frozen decisions (D1–D5 below) — gate before any code beyond M2 | 🔴 blocking |
+| **M1** | PatchTST inference module decoupled from the training `Learner`: `predict(window) -> reconstruction`, RevIN normalization, checkpoint loaded once per worker | P0 |
+| **M1.5** | **Connector SPI**: pivot schema + `SourceConnector`/`SinkConnector` contracts + `registry` + contract/conformance test suite | P0 |
+| **M2** | Beam batch skeleton on DirectRunner: source → windowing → sink, no model. Validates pivot schema end-to-end (dev/test only, never prod) | P0 |
+| **M3** | PatchTST in the pipeline via `RunInference` with a custom PyTorch `ModelHandler`: per-worker load, batching, device. Output enriched with reconstruction + error | P0 |
+| **M4** | Variation detection: static thresholding first, then adaptive (rolling quantile / MAD) per `series_id`, plus anti-flapping (hysteresis, debounce) | P0 |
+| **M5** | Streaming: same pipeline unbounded — sliding windows, watermarks, late data, triggering | P1 |
+| **M6** | Production runner (Flink on-K8s or Dataflow) + pipeline monitoring (lag, throughput, failures) | P1 |
+| **M7** | KubeVerdict alerting + optional retraining loop back to the datalake | P2 |
+
+## Critical path (batch POC)
+
+```
+M0 → M1 → M1.5 → M2 → M3 → M4
+```
+
+End-to-end variation detection on historical data, without touching streaming or
+Flink. This de-risks the two fragile joints — inference-in-Beam and the model's
+real value — before investing in streaming ops.
+
+## Connector workstream
+
+Once the SPI (M1.5) is frozen, each connector is a small, parallelizable PR:
+drop a file under `connectors/sources/` or `connectors/sinks/` with
+`@connector("name")` and pass the conformance suite. P0 connectors for the POC:
+**Mimir (C9a)** source and **MinIO/Iceberg (C11/C18)** sink.
+
+## Open decisions
+
+| #  | Question | Proposed default |
+|----|----------|------------------|
+| D1 | Detection: reconstruction vs forecast+residual | **Reconstruction** (self-supervised) |
+| D2 | Mimir as sole ingress, or Kafka/OTLP in parallel for low-latency live? | TBD |
+| D3 | Plugin discovery: internal registry vs Python entry-points (third-party plugins) | Internal first |
+| D4 | Pivot schema: univariate vs native multivariate (PatchTST channel-independence) | TBD |
+| D5 | Datalake purpose: retraining vs analytics/compliance vs both | TBD |
+
+## Scope note — SPI vs catalog
+
+The real P0 deliverable is **not** "write the Mimir and MinIO connectors". It is
+freezing the **pivot contract + registry + conformance suite** (M1.5). After
+that, Mimir / Kafka / MinIO / ClickHouse are a few files each, written in
+parallel without touching the core.


### PR DESCRIPTION
Document the metrics variation-detection design on PatchTST:
- ARCHITECTURE: vision, sovereign target flow, reconstruction-based detection, connector SPI (pivot schema + registry), sovereignty model
- CONNECTORS: plugin catalog (Mimir, MinIO/Iceberg, ClickHouse, ...) with GCP equivalents and sovereignty tiers
- ROADMAP: milestones M0-M7, batch-POC critical path, open decisions