### PR TITLE
feat(inference): PatchTST inference engine — both heads, load-once (M1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -463,3 +463,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/emacs,jetbrains+all,jupyternotebooks,linux,macos,microsoftoffice,notepadpp,python,tortoisegit,vim,visualstudiocode,windows
+
+# local virtualenv / coverage
+.venv/
+.coverage

--- a/connectors/__init__.py
+++ b/connectors/__init__.py
@@ -1,0 +1,23 @@
+"""Connector SPI package (M1.5).
+
+Public surface: the pivot schema, the Source/Sink contracts, and the registry.
+Concrete connectors are registered by explicit import below (decision D3,
+internal registry) — importing this package makes the built-in plugins
+available via ``build("name", ...)``.
+"""
+from .base import SinkConnector, SourceConnector
+from .pivot import PivotRow
+from .registry import available, build, connector
+
+# Register built-in connectors (side-effect imports).
+from .sources import mimir as _mimir  # noqa: E402,F401
+from .sinks import parquet as _parquet  # noqa: E402,F401
+
+__all__ = [
+    "PivotRow",
+    "SourceConnector",
+    "SinkConnector",
+    "connector",
+    "build",
+    "available",
+]

--- a/connectors/__init__.py
+++ b/connectors/__init__.py
@@ -6,6 +6,7 @@ internal registry) — importing this package makes the built-in plugins
 available via ``build("name", ...)``.
 """
 from .base import SinkConnector, SourceConnector
+from .engines import Engine, LocalEngine
 from .pivot import PivotRow
 from .registry import available, build, connector
 
@@ -20,4 +21,6 @@ __all__ = [
     "connector",
     "build",
     "available",
+    "Engine",
+    "LocalEngine",
 ]

--- a/connectors/alignment.py
+++ b/connectors/alignment.py
@@ -1,0 +1,93 @@
+"""Temporal alignment — where the multivariate 'what doesn't match' is paid.
+
+K8s channels arrive on different cadences (CPU @15s, custom @60s, remote-write
+with jitter). To build the [n_channels, context_len] window PatchTST expects,
+every channel of a group must sit on a common time grid. This module turns
+per-channel timestamped points into aligned multivariate ``PivotRow`` records.
+
+This is the alignment cost that decision D4 (native multivariate) moves into the
+source connector. It is pure-Python and unit-testable without Beam.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Literal
+
+from .pivot import PivotRow
+
+FillPolicy = Literal["ffill", "zero", "drop"]
+
+
+def _snap(ts: int, step_ms: int) -> int:
+    """Floor a timestamp onto the grid of width ``step_ms``."""
+    return (ts // step_ms) * step_ms
+
+
+def align_group(
+    group_id: str,
+    series: dict[str, Iterable[tuple[int, float]]],
+    *,
+    step_ms: int,
+    fill: FillPolicy = "ffill",
+    labels: dict[str, str] | None = None,
+) -> list[PivotRow]:
+    """Align one group's channels onto a common grid.
+
+    Args:
+        group_id: identity shared by all channels in this group.
+        series: channel name -> iterable of (epoch_ms, value), any cadence.
+        step_ms: grid resolution; timestamps are floored to this step.
+        fill: gap policy when a channel has no sample in a grid bucket.
+            ``ffill`` carries the last known value forward, ``zero`` uses 0.0,
+            ``drop`` omits any grid point not covered by every channel.
+        labels: optional metadata copied onto each row.
+
+    Returns:
+        Aligned rows, ascending by ts. ``channels`` order is the sorted channel
+        names (stable for a given group), so output positions are deterministic.
+    """
+    channels = sorted(series)
+    if not channels:
+        return []
+
+    # bucket -> {channel: last value in/under that bucket}
+    bucketed: dict[str, dict[int, float]] = {}
+    grid: set[int] = set()
+    for ch in channels:
+        last_per_bucket: dict[int, float] = {}
+        for ts, val in sorted(series[ch]):
+            last_per_bucket[_snap(ts, step_ms)] = float(val)
+        bucketed[ch] = last_per_bucket
+        grid.update(last_per_bucket)
+
+    rows: list[PivotRow] = []
+    carried: dict[str, float | None] = {ch: None for ch in channels}
+    for g in sorted(grid):
+        values: list[float] = []
+        complete = True
+        for ch in channels:
+            if g in bucketed[ch]:
+                carried[ch] = bucketed[ch][g]
+            if carried[ch] is None:
+                # no value seen yet for this channel
+                if fill == "zero":
+                    values.append(0.0)
+                else:  # ffill or drop: cannot fill from nothing
+                    complete = False
+                    break
+            else:
+                values.append(carried[ch])
+        if not complete:
+            if fill == "drop":
+                continue
+            # ffill with no prior value at grid start: skip until covered
+            continue
+        rows.append(
+            PivotRow(
+                group_id=group_id,
+                ts=g,
+                values=tuple(values),
+                channels=tuple(channels),
+                labels=dict(labels or {}),
+            )
+        )
+    return rows

--- a/connectors/base.py
+++ b/connectors/base.py
@@ -1,0 +1,50 @@
+"""Connector SPI — the open extension point (M1.5).
+
+Two contracts, one pivot schema. The core (windowing -> PatchTST -> detection)
+depends only on these abstractions, never on a concrete connector. Adding a
+connector means implementing one of these and registering it with
+``@connector`` (see ``connectors.registry``).
+
+``apache_beam`` is imported lazily inside ``read``/``write`` implementations so
+that the pure-Python parts of this package (pivot, registry, alignment,
+conformance) remain importable and testable without a Beam install.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # avoid hard beam import at module load
+    import apache_beam as beam
+
+
+class SourceConnector(ABC):
+    """Produces ``PivotRow`` records into the pipeline.
+
+    Implementations own ingestion concerns the core must not know about:
+    querying the backend, and (for multivariate) temporal alignment of
+    heterogeneous channels onto a common grid before emitting rows.
+    """
+
+    kind = "source"
+
+    @abstractmethod
+    def read(self) -> "beam.PTransform":
+        """Return a PTransform: () -> PCollection[PivotRow]."""
+
+    def describe(self) -> dict[str, Any]:
+        """Optional human/debug description of the configured source."""
+        return {"kind": self.kind, "type": type(self).__name__}
+
+
+class SinkConnector(ABC):
+    """Consumes pipeline output (detections, enriched rows) to an external store."""
+
+    kind = "sink"
+
+    @abstractmethod
+    def write(self) -> "beam.PTransform":
+        """Return a PTransform: PCollection -> writes out (returns PDone/None)."""
+
+    def describe(self) -> dict[str, Any]:
+        return {"kind": self.kind, "type": type(self).__name__}

--- a/connectors/base.py
+++ b/connectors/base.py
@@ -1,25 +1,35 @@
-"""Connector SPI — the open extension point (M1.5).
+"""Connector SPI — engine-agnostic contract (M1.5, decision D6).
 
-Two contracts, one pivot schema. The core (windowing -> PatchTST -> detection)
-depends only on these abstractions, never on a concrete connector. Adding a
-connector means implementing one of these and registering it with
-``@connector`` (see ``connectors.registry``).
+A connector is defined in pure-Python, domain terms only: a source *yields*
+``PivotRow`` records, a sink *consumes* them. No execution engine appears in the
+contract — Beam, Spark/Databricks, or a plain-Python runner are **adapters**
+behind the boundary (see ``connectors.engines``), never baked into the core.
 
-``apache_beam`` is imported lazily inside ``read``/``write`` implementations so
-that the pure-Python parts of this package (pivot, registry, alignment,
-conformance) remain importable and testable without a Beam install.
+Why this shape:
+- connectors are testable and runnable without any engine installed;
+- the same connector runs under Beam, Spark/Databricks, or locally;
+- swapping or adding an engine touches ``engines/``, never the connectors.
+
+**Native capability hook.** A pure-iterator source cannot express an engine's
+native distributed/unbounded I/O (e.g. a Kafka streaming source, or a parallel
+Parquet writer). A connector may therefore expose an engine-native override; the
+engine adapter uses it when present and falls back to the agnostic iterator
+otherwise. Hooks return ``None`` by default and import their engine lazily, so
+the core stays engine-free.
 """
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 
-if TYPE_CHECKING:  # avoid hard beam import at module load
+from .pivot import PivotRow
+
+if TYPE_CHECKING:  # never imported at runtime by the core
     import apache_beam as beam
 
 
 class SourceConnector(ABC):
-    """Produces ``PivotRow`` records into the pipeline.
+    """Yields ``PivotRow`` records. Engine-agnostic.
 
     Implementations own ingestion concerns the core must not know about:
     querying the backend, and (for multivariate) temporal alignment of
@@ -29,8 +39,15 @@ class SourceConnector(ABC):
     kind = "source"
 
     @abstractmethod
-    def read(self) -> "beam.PTransform":
-        """Return a PTransform: () -> PCollection[PivotRow]."""
+    def read(self) -> Iterable[PivotRow]:
+        """Produce pivot rows. Pure Python — no engine types."""
+
+    def native_beam_read(self) -> "beam.PTransform | None":
+        """Optional Beam-native source (e.g. unbounded Kafka).
+
+        Return ``None`` (default) to let the Beam adapter wrap ``read()``.
+        """
+        return None
 
     def describe(self) -> dict[str, Any]:
         """Optional human/debug description of the configured source."""
@@ -38,13 +55,21 @@ class SourceConnector(ABC):
 
 
 class SinkConnector(ABC):
-    """Consumes pipeline output (detections, enriched rows) to an external store."""
+    """Consumes records (e.g. pivot rows or detections). Engine-agnostic."""
 
     kind = "sink"
 
     @abstractmethod
-    def write(self) -> "beam.PTransform":
-        """Return a PTransform: PCollection -> writes out (returns PDone/None)."""
+    def write(self, rows: Iterable[Any]) -> None:
+        """Consume an iterable of records. Pure Python — no engine types."""
+
+    def native_beam_write(self) -> "beam.PTransform | None":
+        """Optional Beam-native sink (e.g. a parallel/distributed writer).
+
+        Return ``None`` (default) to let the Beam adapter gather-and-call
+        ``write()``.
+        """
+        return None
 
     def describe(self) -> dict[str, Any]:
         return {"kind": self.kind, "type": type(self).__name__}

--- a/connectors/conformance.py
+++ b/connectors/conformance.py
@@ -1,9 +1,8 @@
 """Conformance suite — the contract every connector plugin must satisfy.
 
-Reusable assertions so a new connector PR proves it honors the SPI without
-re-inventing checks. The beam-dependent parts (actually running read/write) are
-exercised in integration tests; these checks validate the contract surface and
-registration, and run without a Beam install.
+Reusable assertions so a new connector PR proves it honors the engine-agnostic
+SPI without re-inventing checks. These run with no engine installed; engine
+execution is exercised by the per-engine integration tests.
 """
 from __future__ import annotations
 
@@ -22,6 +21,10 @@ def assert_source_contract(instance: SourceConnector) -> None:
     assert isinstance(instance, SourceConnector), "must be a SourceConnector"
     assert instance.kind == "source"
     assert callable(getattr(instance, "read", None)), "must implement read()"
+    # engine-agnostic: native hook is optional and defaults to None
+    assert instance.native_beam_read() is None or hasattr(
+        instance.native_beam_read(), "expand"
+    ), "native_beam_read must return None or a Beam PTransform"
     desc = instance.describe()
     assert desc["kind"] == "source" and "type" in desc
 

--- a/connectors/conformance.py
+++ b/connectors/conformance.py
@@ -1,0 +1,45 @@
+"""Conformance suite — the contract every connector plugin must satisfy.
+
+Reusable assertions so a new connector PR proves it honors the SPI without
+re-inventing checks. The beam-dependent parts (actually running read/write) are
+exercised in integration tests; these checks validate the contract surface and
+registration, and run without a Beam install.
+"""
+from __future__ import annotations
+
+from .base import SinkConnector, SourceConnector
+from .registry import _REGISTRY, build
+
+
+def assert_registered(name: str) -> type:
+    """The name resolves to a registered connector class."""
+    assert name in _REGISTRY, f"{name!r} not registered"
+    return _REGISTRY[name]
+
+
+def assert_source_contract(instance: SourceConnector) -> None:
+    """Instance honors the SourceConnector surface."""
+    assert isinstance(instance, SourceConnector), "must be a SourceConnector"
+    assert instance.kind == "source"
+    assert callable(getattr(instance, "read", None)), "must implement read()"
+    desc = instance.describe()
+    assert desc["kind"] == "source" and "type" in desc
+
+
+def assert_sink_contract(instance: SinkConnector) -> None:
+    """Instance honors the SinkConnector surface."""
+    assert isinstance(instance, SinkConnector), "must be a SinkConnector"
+    assert instance.kind == "sink"
+    assert callable(getattr(instance, "write", None)), "must implement write()"
+    desc = instance.describe()
+    assert desc["kind"] == "sink" and "type" in desc
+
+
+def assert_buildable(name: str, **cfg) -> object:
+    """The connector can be instantiated from config via the registry."""
+    instance = build(name, **cfg)
+    if instance.kind == "source":
+        assert_source_contract(instance)  # type: ignore[arg-type]
+    else:
+        assert_sink_contract(instance)  # type: ignore[arg-type]
+    return instance

--- a/connectors/engines/__init__.py
+++ b/connectors/engines/__init__.py
@@ -1,0 +1,11 @@
+"""Execution engines (adapters).
+
+The core and connectors are engine-agnostic; an ``Engine`` adapter runs a
+source → sinks flow on a concrete runtime. ``LocalEngine`` needs no third-party
+dependency; ``BeamEngine`` runs on Apache Beam. A Spark/Databricks adapter is the
+next planned engine.
+"""
+from .base import Engine
+from .local import LocalEngine
+
+__all__ = ["Engine", "LocalEngine"]

--- a/connectors/engines/base.py
+++ b/connectors/engines/base.py
@@ -8,16 +8,23 @@ same pipeline plug into any engine.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import Any, Callable, Iterable, Optional, Sequence
 
 from ..base import SinkConnector, SourceConnector
 
+# An optional stage applied between read and write: rows in, records out
+# (e.g. variation detection: Iterable[PivotRow] -> Iterable[SignalRecord]).
+Transform = Callable[[Iterable[Any]], Iterable[Any]]
+
 
 class Engine(ABC):
-    """Runs a source into one or more sinks on a concrete runtime."""
+    """Runs a source → (transform) → sinks flow on a concrete runtime."""
 
     @abstractmethod
     def run(
-        self, source: SourceConnector, sinks: Sequence[SinkConnector]
+        self,
+        source: SourceConnector,
+        sinks: Sequence[SinkConnector],
+        transform: Optional[Transform] = None,
     ) -> None:
-        """Read from ``source`` and write to every sink in ``sinks``."""
+        """Read from ``source``, optionally ``transform``, write to every sink."""

--- a/connectors/engines/base.py
+++ b/connectors/engines/base.py
@@ -1,0 +1,23 @@
+"""Engine port — the boundary between the agnostic core and a runtime.
+
+An engine knows how to execute a ``source → sinks`` flow on a concrete runtime
+(plain Python, Beam, Spark/Databricks). Connectors never depend on it; it depends
+on connectors. This is the "ports & adapters" hexagonal boundary that lets the
+same pipeline plug into any engine.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Sequence
+
+from ..base import SinkConnector, SourceConnector
+
+
+class Engine(ABC):
+    """Runs a source into one or more sinks on a concrete runtime."""
+
+    @abstractmethod
+    def run(
+        self, source: SourceConnector, sinks: Sequence[SinkConnector]
+    ) -> None:
+        """Read from ``source`` and write to every sink in ``sinks``."""

--- a/connectors/engines/beam.py
+++ b/connectors/engines/beam.py
@@ -7,10 +7,10 @@ for sinks. ``apache_beam`` is imported lazily so the core never needs it.
 """
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Optional, Sequence
 
 from ..base import SinkConnector, SourceConnector
-from .base import Engine
+from .base import Engine, Transform
 
 
 class BeamEngine(Engine):
@@ -18,7 +18,10 @@ class BeamEngine(Engine):
         self._options = pipeline_options
 
     def run(
-        self, source: SourceConnector, sinks: Sequence[SinkConnector]
+        self,
+        source: SourceConnector,
+        sinks: Sequence[SinkConnector],
+        transform: Optional[Transform] = None,
     ) -> None:
         import apache_beam as beam
 
@@ -29,6 +32,15 @@ class BeamEngine(Engine):
                 if native_read is not None
                 else beam.Create(list(source.read()))
             )
+            if transform is not None:
+                # Iterable->Iterable transform (e.g. detection): gather the
+                # bundle, apply, fan back out. Batch-oriented; engine-native
+                # windowed detection is a later optimization.
+                pcoll = (
+                    pcoll
+                    | "ToListT" >> beam.combiners.ToList()
+                    | "Transform" >> beam.FlatMap(lambda rows: list(transform(rows)))
+                )
             for i, sink in enumerate(sinks):
                 native_write = sink.native_beam_write()
                 if native_write is not None:

--- a/connectors/engines/beam.py
+++ b/connectors/engines/beam.py
@@ -1,0 +1,44 @@
+"""Beam engine — adapter running connectors on Apache Beam.
+
+Uses a connector's engine-native hook when present (e.g. an unbounded Kafka
+source, or a distributed Parquet writer), and otherwise lifts the agnostic
+iterator: ``beam.Create(source.read())`` for reads, gather-and-call ``write()``
+for sinks. ``apache_beam`` is imported lazily so the core never needs it.
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from ..base import SinkConnector, SourceConnector
+from .base import Engine
+
+
+class BeamEngine(Engine):
+    def __init__(self, pipeline_options=None) -> None:
+        self._options = pipeline_options
+
+    def run(
+        self, source: SourceConnector, sinks: Sequence[SinkConnector]
+    ) -> None:
+        import apache_beam as beam
+
+        with beam.Pipeline(options=self._options) as p:
+            native_read = source.native_beam_read()
+            pcoll = p | "Read" >> (
+                native_read
+                if native_read is not None
+                else beam.Create(list(source.read()))
+            )
+            for i, sink in enumerate(sinks):
+                native_write = sink.native_beam_write()
+                if native_write is not None:
+                    pcoll | f"Write{i}" >> native_write
+                else:
+                    # Fallback: gather to one bundle and call the agnostic
+                    # write(). Fine for batch/small; native writers should be
+                    # provided for large or unbounded sinks.
+                    (
+                        pcoll
+                        | f"ToList{i}" >> beam.combiners.ToList()
+                        | f"Write{i}" >> beam.Map(sink.write)
+                    )

--- a/connectors/engines/local.py
+++ b/connectors/engines/local.py
@@ -1,0 +1,22 @@
+"""Local engine — pure-Python execution, zero third-party dependency.
+
+Materializes the source and hands the records to each sink. Ideal for dev,
+tests, and small/batch jobs. Not distributed: a whole read is pulled into one
+process, so it is unsuitable for large or unbounded workloads — use ``BeamEngine``
+(or a Spark/Databricks engine) there.
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+from ..base import SinkConnector, SourceConnector
+from .base import Engine
+
+
+class LocalEngine(Engine):
+    def run(
+        self, source: SourceConnector, sinks: Sequence[SinkConnector]
+    ) -> None:
+        rows = list(source.read())  # materialize once for all sinks
+        for sink in sinks:
+            sink.write(rows)

--- a/connectors/engines/local.py
+++ b/connectors/engines/local.py
@@ -7,16 +7,22 @@ process, so it is unsuitable for large or unbounded workloads — use ``BeamEngi
 """
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Optional, Sequence
 
 from ..base import SinkConnector, SourceConnector
-from .base import Engine
+from .base import Engine, Transform
 
 
 class LocalEngine(Engine):
     def run(
-        self, source: SourceConnector, sinks: Sequence[SinkConnector]
+        self,
+        source: SourceConnector,
+        sinks: Sequence[SinkConnector],
+        transform: Optional[Transform] = None,
     ) -> None:
-        rows = list(source.read())  # materialize once for all sinks
+        rows: object = source.read()
+        if transform is not None:
+            rows = transform(rows)
+        rows = list(rows)  # materialize once for all sinks
         for sink in sinks:
             sink.write(rows)

--- a/connectors/pivot.py
+++ b/connectors/pivot.py
@@ -1,0 +1,52 @@
+"""Pivot schema — the only data contract the processing core understands.
+
+Native multivariate (decision D4): a row carries an aligned vector of channel
+values at a single timestamp. The source connector is responsible for producing
+already-aligned vectors (see ``connectors.alignment``); the core never sees
+unaligned data.
+
+Note on the model mismatch (intentional, documented): PatchTST is
+channel-independent, so it will not exploit cross-channel correlation carried in
+``values``. The grouping buys batching and a group-level detection decision, not
+joint modeling. See docs/ARCHITECTURE.md.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class PivotRow:
+    """One aligned multivariate sample.
+
+    Attributes:
+        group_id: stable identity of the channel group (e.g. a pod/node/service).
+        ts: epoch milliseconds, snapped to the alignment grid by the source.
+        values: channel values, ordered to match ``channels`` position-for-position.
+        channels: ordered channel names; must be stable for a given ``group_id``.
+        labels: free-form metadata (e.g. Prometheus labels), not used by the core.
+    """
+
+    group_id: str
+    ts: int
+    values: tuple[float, ...]
+    channels: tuple[str, ...]
+    labels: dict[str, str] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.group_id:
+            raise ValueError("group_id must be non-empty")
+        if not isinstance(self.ts, int):
+            raise ValueError(f"ts must be int epoch-ms, got {type(self.ts).__name__}")
+        if len(self.values) != len(self.channels):
+            raise ValueError(
+                f"values/channels length mismatch: "
+                f"{len(self.values)} != {len(self.channels)}"
+            )
+        if len(set(self.channels)) != len(self.channels):
+            raise ValueError(f"duplicate channels in {self.channels}")
+
+    @property
+    def width(self) -> int:
+        """Number of channels (n_channels in the [n_channels, L] window)."""
+        return len(self.channels)

--- a/connectors/registry.py
+++ b/connectors/registry.py
@@ -1,0 +1,49 @@
+"""Internal plugin registry (decision D3).
+
+Connectors register themselves with ``@connector("name")`` and are discovered by
+explicit import (see ``connectors/__init__.py``). No entry-points, no packaging
+overhead — sufficient while connectors live in this repo. The contract is small
+enough to swap for ``importlib.metadata`` entry-points later without touching
+call sites.
+"""
+from __future__ import annotations
+
+from typing import Callable, TypeVar
+
+from .base import SinkConnector, SourceConnector
+
+_REGISTRY: dict[str, type] = {}
+
+T = TypeVar("T", bound=type)
+
+
+def connector(name: str) -> Callable[[T], T]:
+    """Register a Source/Sink connector class under ``name``."""
+
+    def deco(cls: T) -> T:
+        if not issubclass(cls, (SourceConnector, SinkConnector)):
+            raise TypeError(
+                f"{cls.__name__} must subclass SourceConnector or SinkConnector"
+            )
+        if name in _REGISTRY and _REGISTRY[name] is not cls:
+            raise ValueError(f"connector name {name!r} already registered")
+        _REGISTRY[name] = cls
+        return cls
+
+    return deco
+
+
+def build(name: str, **cfg):
+    """Instantiate a registered connector from config."""
+    try:
+        cls = _REGISTRY[name]
+    except KeyError:
+        raise KeyError(
+            f"unknown connector {name!r}; available: {sorted(_REGISTRY)}"
+        ) from None
+    return cls(**cfg)
+
+
+def available() -> dict[str, str]:
+    """Map of registered name -> 'source'|'sink'."""
+    return {name: cls.kind for name, cls in sorted(_REGISTRY.items())}

--- a/connectors/sinks/__init__.py
+++ b/connectors/sinks/__init__.py
@@ -1,0 +1,1 @@
+"""Sink connectors."""

--- a/connectors/sinks/parquet.py
+++ b/connectors/sinks/parquet.py
@@ -1,15 +1,16 @@
 """Parquet sink (connector C11/C18 stepping stone).
 
-Writes pipeline output as Parquet. Targets a local path for the batch POC and an
-S3-compatible store (MinIO) via an ``s3://`` path once ``s3fs``/filesystem is
-configured — same code, sovereign substrate. Iceberg table format (C18) layers
-on top later without changing the connector contract.
+Writes records as Parquet. Targets a local path and, via the S3 API, any
+S3-compatible store; Iceberg (C18) layers on later without changing the contract.
 
-Beam is imported lazily in ``write``.
+Engine-agnostic ``write`` uses pyarrow directly (no engine needed). Under Beam,
+the native hook ``native_beam_write`` provides a distributed ``WriteToParquet``
+instead. pyarrow / beam are imported lazily so the core stays dependency-free.
 """
 from __future__ import annotations
 
 import json
+from typing import Any, Iterable
 
 from ..base import SinkConnector
 from ..registry import connector
@@ -55,7 +56,20 @@ class ParquetSink(SinkConnector):
             "labels": json.dumps(dict(row.labels), sort_keys=True),
         }
 
-    def write(self):
+    def local_path(self) -> str:
+        """Single-file output path used by the agnostic writer."""
+        return f"{self.path}{self.file_name_suffix}"
+
+    def write(self, rows: Iterable[Any]) -> None:
+        """Engine-agnostic write: materialize records and write one Parquet file."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        records = [self.as_record(r) for r in rows]
+        table = pa.Table.from_pylist(records, schema=self._pyarrow_schema())
+        pq.write_table(table, self.local_path())
+
+    def native_beam_write(self):
         import apache_beam as beam  # lazy
         from apache_beam.io.parquetio import WriteToParquet
 

--- a/connectors/sinks/parquet.py
+++ b/connectors/sinks/parquet.py
@@ -1,0 +1,83 @@
+"""Parquet sink (connector C11/C18 stepping stone).
+
+Writes pipeline output as Parquet. Targets a local path for the batch POC and an
+S3-compatible store (MinIO) via an ``s3://`` path once ``s3fs``/filesystem is
+configured — same code, sovereign substrate. Iceberg table format (C18) layers
+on top later without changing the connector contract.
+
+Beam is imported lazily in ``write``.
+"""
+from __future__ import annotations
+
+import json
+
+from ..base import SinkConnector
+from ..registry import connector
+
+
+@connector("parquet")
+class ParquetSink(SinkConnector):
+    """Write rows (e.g. PivotRow-derived detections) to Parquet files."""
+
+    def __init__(
+        self,
+        path: str,
+        *,
+        file_name_suffix: str = ".parquet",
+        num_shards: int = 0,
+    ) -> None:
+        self.path = path
+        self.file_name_suffix = file_name_suffix
+        self.num_shards = num_shards
+
+    def _pyarrow_schema(self):
+        import pyarrow as pa  # lazy
+
+        # labels stored as a JSON string for a robust, schema-stable round-trip.
+        return pa.schema(
+            [
+                ("group_id", pa.string()),
+                ("ts", pa.int64()),
+                ("channels", pa.list_(pa.string())),
+                ("values", pa.list_(pa.float64())),
+                ("labels", pa.string()),
+            ]
+        )
+
+    @staticmethod
+    def as_record(row) -> dict:
+        """PivotRow (or detection row) -> flat Arrow-friendly dict."""
+        return {
+            "group_id": row.group_id,
+            "ts": int(row.ts),
+            "channels": list(row.channels),
+            "values": [float(v) for v in row.values],
+            "labels": json.dumps(dict(row.labels), sort_keys=True),
+        }
+
+    def write(self):
+        import apache_beam as beam  # lazy
+        from apache_beam.io.parquetio import WriteToParquet
+
+        schema = self._pyarrow_schema()
+        path, suffix, shards = self.path, self.file_name_suffix, self.num_shards
+        as_record = self.as_record
+
+        class _ToParquet(beam.PTransform):
+            def expand(self, pcoll):
+                return (
+                    pcoll
+                    | "AsRecord" >> beam.Map(as_record)
+                    | "WriteParquet"
+                    >> WriteToParquet(
+                        file_path_prefix=path,
+                        schema=schema,
+                        file_name_suffix=suffix,
+                        num_shards=shards,
+                    )
+                )
+
+        return _ToParquet()
+
+    def describe(self):
+        return {**super().describe(), "path": self.path}

--- a/connectors/sources/__init__.py
+++ b/connectors/sources/__init__.py
@@ -1,0 +1,1 @@
+"""Source connectors."""

--- a/connectors/sources/mimir.py
+++ b/connectors/sources/mimir.py
@@ -1,0 +1,150 @@
+"""Grafana Mimir source (connector C9a).
+
+Reads historical metrics via Mimir's Prometheus-compatible ``query_range`` API
+and emits aligned multivariate ``PivotRow`` records. This connector owns the
+alignment cost (decision D4): it groups raw series by ``group_by`` labels and
+aligns their channels onto a common grid before emitting.
+
+The HTTP query is stdlib-only and unit-testable; Beam is imported lazily in
+``read`` so importing this module does not require a Beam install.
+"""
+from __future__ import annotations
+
+import json
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+
+from ..alignment import FillPolicy, align_group
+from ..base import SourceConnector
+from ..pivot import PivotRow
+from ..registry import connector
+
+
+def query_range(
+    endpoint: str,
+    promql: str,
+    start: int,
+    end: int,
+    step_s: int,
+    *,
+    tenant: str | None = None,
+    timeout: float = 30.0,
+) -> list[dict]:
+    """Call Mimir/Prometheus ``/api/v1/query_range``; return the result list.
+
+    Args separate from the connector so this can be mocked in tests.
+    """
+    params = urllib.parse.urlencode(
+        {"query": promql, "start": start, "end": end, "step": f"{step_s}s"}
+    )
+    url = f"{endpoint.rstrip('/')}/prometheus/api/v1/query_range?{params}"
+    req = urllib.request.Request(url)
+    if tenant:
+        req.add_header("X-Scope-OrgID", tenant)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        payload = json.loads(resp.read())
+    if payload.get("status") != "success":
+        raise RuntimeError(f"Mimir query failed: {payload.get('error', payload)}")
+    return payload["data"]["result"]
+
+
+def to_pivot_rows(
+    result: list[dict],
+    *,
+    group_by: list[str],
+    channel_label: str,
+    step_ms: int,
+    fill: FillPolicy,
+) -> list[PivotRow]:
+    """Turn a Prometheus matrix result into aligned multivariate rows.
+
+    Series are grouped by the ``group_by`` label values (-> group_id); the
+    ``channel_label`` value names each channel within a group.
+    """
+    # group_id -> channel -> [(ts_ms, value)]
+    groups: dict[str, dict[str, list[tuple[int, float]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    group_labels: dict[str, dict[str, str]] = {}
+    for series in result:
+        metric = series.get("metric", {})
+        gid = "/".join(metric.get(k, "") for k in group_by) or "default"
+        channel = metric.get(channel_label, metric.get("__name__", "value"))
+        group_labels.setdefault(gid, {k: metric.get(k, "") for k in group_by})
+        for ts_s, val in series.get("values", []):
+            groups[gid][channel].append((int(float(ts_s) * 1000), float(val)))
+
+    rows: list[PivotRow] = []
+    for gid, series_map in groups.items():
+        rows.extend(
+            align_group(
+                gid,
+                series_map,
+                step_ms=step_ms,
+                fill=fill,
+                labels=group_labels.get(gid),
+            )
+        )
+    return rows
+
+
+@connector("mimir")
+class MimirSource(SourceConnector):
+    """Historical multivariate source backed by Grafana Mimir."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        promql: str,
+        start: int,
+        end: int,
+        *,
+        step_s: int = 15,
+        group_by: list[str] | None = None,
+        channel_label: str = "__name__",
+        fill: FillPolicy = "ffill",
+        tenant: str | None = None,
+    ) -> None:
+        self.endpoint = endpoint
+        self.promql = promql
+        self.start = start
+        self.end = end
+        self.step_s = step_s
+        self.group_by = group_by or ["instance"]
+        self.channel_label = channel_label
+        self.fill = fill
+        self.tenant = tenant
+
+    def _fetch_rows(self) -> list[PivotRow]:
+        result = query_range(
+            self.endpoint,
+            self.promql,
+            self.start,
+            self.end,
+            self.step_s,
+            tenant=self.tenant,
+        )
+        return to_pivot_rows(
+            result,
+            group_by=self.group_by,
+            channel_label=self.channel_label,
+            step_ms=self.step_s * 1000,
+            fill=self.fill,
+        )
+
+    def read(self):
+        import apache_beam as beam  # lazy: keep module importable without beam
+
+        # Batch/replay: materialize the query, then fan out as a PCollection.
+        # Streaming live ingestion is a separate connector (M5).
+        return beam.Create(self._fetch_rows())
+
+    def describe(self):
+        return {
+            **super().describe(),
+            "endpoint": self.endpoint,
+            "promql": self.promql,
+            "group_by": self.group_by,
+            "step_s": self.step_s,
+        }

--- a/connectors/sources/mimir.py
+++ b/connectors/sources/mimir.py
@@ -133,12 +133,11 @@ class MimirSource(SourceConnector):
             fill=self.fill,
         )
 
-    def read(self):
-        import apache_beam as beam  # lazy: keep module importable without beam
-
-        # Batch/replay: materialize the query, then fan out as a PCollection.
-        # Streaming live ingestion is a separate connector (M5).
-        return beam.Create(self._fetch_rows())
+    def read(self) -> list[PivotRow]:
+        # Engine-agnostic: yield aligned rows. Batch/replay over Mimir's history.
+        # The Beam adapter wraps this in beam.Create; streaming live ingestion is
+        # a separate (Kafka/OTLP) source with its own native unbounded read (M5).
+        return self._fetch_rows()
 
     def describe(self):
         return {

--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -8,12 +8,15 @@ from .aggregate import detect_signals, make_detection_transform
 from .detector import Detector, ZScoreDetector
 from .patchtst import PatchTSTDetector
 from .reconstruction import ReconstructionDetector
+from .regime import InMemoryRegimeState, RegimeSwitchDetector
 
 __all__ = [
     "Detector",
     "ZScoreDetector",
     "PatchTSTDetector",
     "ReconstructionDetector",
+    "RegimeSwitchDetector",
+    "InMemoryRegimeState",
     "detect_signals",
     "make_detection_transform",
 ]

--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -7,11 +7,13 @@ and hand it to an engine: ``Engine.run(source, sinks, transform=...)``.
 from .aggregate import detect_signals, make_detection_transform
 from .detector import Detector, ZScoreDetector
 from .patchtst import PatchTSTDetector
+from .reconstruction import ReconstructionDetector
 
 __all__ = [
     "Detector",
     "ZScoreDetector",
     "PatchTSTDetector",
+    "ReconstructionDetector",
     "detect_signals",
     "make_detection_transform",
 ]

--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -6,10 +6,12 @@ and hand it to an engine: ``Engine.run(source, sinks, transform=...)``.
 """
 from .aggregate import detect_signals, make_detection_transform
 from .detector import Detector, ZScoreDetector
+from .patchtst import PatchTSTDetector
 
 __all__ = [
     "Detector",
     "ZScoreDetector",
+    "PatchTSTDetector",
     "detect_signals",
     "make_detection_transform",
 ]

--- a/detection/__init__.py
+++ b/detection/__init__.py
@@ -1,0 +1,15 @@
+"""Variation detection — PivotRows → SignalRecords.
+
+The detection stage between a source and the knowledge-base sink. Plug a
+``Detector`` (ZScoreDetector now; PatchTST later) into ``make_detection_transform``
+and hand it to an engine: ``Engine.run(source, sinks, transform=...)``.
+"""
+from .aggregate import detect_signals, make_detection_transform
+from .detector import Detector, ZScoreDetector
+
+__all__ = [
+    "Detector",
+    "ZScoreDetector",
+    "detect_signals",
+    "make_detection_transform",
+]

--- a/detection/aggregate.py
+++ b/detection/aggregate.py
@@ -1,0 +1,59 @@
+"""Detection transform — PivotRows (raw metrics) → SignalRecords (signals).
+
+This is the pipeline stage between a source and the signal-store sink. It groups
+the multivariate ``PivotRow`` stream by entity (``group_id``) and channel into
+per-metric series, runs the detector once per (entity, metric), and emits one
+``SignalRecord`` per assessment.
+
+Pure Python and engine-agnostic: it is the ``transform`` an engine applies
+between ``read`` and ``write`` (LocalEngine / BeamEngine).
+"""
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from typing import Callable, Iterable, Iterator
+
+from connectors.pivot import PivotRow
+from kb.signal import SignalRecord
+
+from .detector import Detector
+
+
+def detect_signals(
+    rows: Iterable[PivotRow],
+    detector: Detector,
+    *,
+    now_ms: int | None = None,
+) -> Iterator[SignalRecord]:
+    """One SignalRecord per (entity, metric) assessed over its window."""
+    ts = now_ms if now_ms is not None else int(time.time() * 1000)
+
+    # group_id -> channel -> [(ts, value)]
+    series: dict[str, dict[str, list[tuple[int, float]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
+    labels: dict[str, dict] = {}
+    for r in rows:
+        labels[r.group_id] = dict(r.labels)
+        for ch, val in zip(r.channels, r.values):
+            series[r.group_id][ch].append((r.ts, float(val)))
+
+    for group_id, channels in series.items():
+        for channel, points in channels.items():
+            points.sort()
+            values = [v for _, v in points]
+            yield detector.detect(
+                group_id, channel, values, ts, labels=labels.get(group_id)
+            )
+
+
+def make_detection_transform(
+    detector: Detector, *, now_ms: int | None = None
+) -> Callable[[Iterable[PivotRow]], Iterator[SignalRecord]]:
+    """Bind a detector into a transform callable for ``Engine.run(..., transform=)``."""
+
+    def _transform(rows: Iterable[PivotRow]) -> Iterator[SignalRecord]:
+        return detect_signals(rows, detector, now_ms=now_ms)
+
+    return _transform

--- a/detection/detector.py
+++ b/detection/detector.py
@@ -1,0 +1,90 @@
+"""Variation detectors — turn a metric window into a SignalRecord.
+
+The ``Detector`` interface is the seam where detection strategy plugs in.
+``ZScoreDetector`` is a real statistical detector (not a stub): it mirrors the
+z-score method and severity semantics of kube-verdict's own fallback, so the
+signals we aggregate speak its language. A PatchTST-based detector (forecast /
+reconstruction) can later implement the same interface without touching the
+pipeline — see docs/ARCHITECTURE.md (D1).
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+from kb.signal import SignalRecord
+
+
+class Detector(ABC):
+    """Assess one metric series for one entity → a SignalRecord."""
+
+    @abstractmethod
+    def detect(
+        self,
+        entity_uid: str,
+        metric_name: str,
+        values: Sequence[float],
+        ts: int,
+        labels: dict | None = None,
+    ) -> SignalRecord:
+        ...
+
+
+@dataclass
+class ZScoreDetector(Detector):
+    """Robust z-score on the most recent fraction of the window.
+
+    score = max |z| over the recent tail; severity by threshold. Real math on
+    real values — kube-verdict uses the same method as its short-signal fallback.
+    """
+
+    warning: float = 3.0
+    critical: float = 4.5
+    min_points: int = 8
+    recent_fraction: float = 0.25
+
+    method = "zscore"
+
+    def _severity(self, score: float) -> str:
+        if score >= self.critical:
+            return "critical"
+        if score >= self.warning:
+            return "warning"
+        return "normal"
+
+    def detect(
+        self,
+        entity_uid: str,
+        metric_name: str,
+        values: Sequence[float],
+        ts: int,
+        labels: dict | None = None,
+    ) -> SignalRecord:
+        v = np.asarray(values, dtype=np.float64)
+        n = int(v.size)
+
+        if n < max(3, self.min_points):
+            score = 0.0
+        else:
+            mu = float(v.mean())
+            sigma = float(v.std())
+            if sigma < 1e-8:
+                score = 0.0
+            else:
+                z = np.abs((v - mu) / sigma)
+                q = max(1, int(n * self.recent_fraction))
+                score = float(z[-q:].max())
+
+        return SignalRecord(
+            entity_uid=entity_uid,
+            metric_name=metric_name,
+            ts=ts,
+            severity=self._severity(score),
+            score=round(score, 4),
+            method=self.method,
+            n_points=n,
+            labels=dict(labels or {}),
+        )

--- a/detection/patchtst.py
+++ b/detection/patchtst.py
@@ -1,0 +1,168 @@
+"""PatchTST forecast-residual detector (decision D1, forecast face).
+
+Trains a small PatchTST forecaster on the early part of a signal, then scores the
+recent window by forecast error relative to the model's own baseline error:
+
+    score = eval_RMSE / baseline_RMSE        (ratio, >1 = worse than usual)
+    score >= warning  -> warning ; >= critical -> critical
+
+This deliberately mirrors kube-verdict's `signals/patchtst_detector.py` method so
+the signals we aggregate match its language. It plugs in behind the ``Detector``
+interface (drop-in for ``ZScoreDetector``); short signals fall back to z-score.
+
+Heavy deps (torch + transformers) are imported lazily inside ``detect`` so the
+``detection`` package and the rest of the pipeline import without them.
+
+Note: training on the fly is accurate and self-contained but compute-heavy — fit
+for periodic/scoped assessment, not high-frequency cluster-wide scoring. A
+pretrained inference variant can replace the training path behind this same class.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import numpy as np
+
+from kb.signal import SignalRecord
+
+from .detector import Detector, ZScoreDetector
+
+log = logging.getLogger(__name__)
+
+
+def _sliding_windows(
+    signal: np.ndarray, context_length: int, prediction_length: int
+) -> list[tuple[np.ndarray, np.ndarray]]:
+    step = max(1, context_length // 4)
+    window = context_length + prediction_length
+    pairs: list[tuple[np.ndarray, np.ndarray]] = []
+    for i in range(0, len(signal) - window + 1, step):
+        ctx = signal[i : i + context_length].copy()
+        tgt = signal[i + context_length : i + window].copy()
+        pairs.append((ctx, tgt))
+    return pairs
+
+
+@dataclass
+class PatchTSTDetector(Detector):
+    context_length: int = 64
+    patch_length: int = 8
+    prediction_length: int = 8
+    d_model: int = 32
+    num_heads: int = 4
+    num_layers: int = 2
+    epochs: int = 30
+    lr: float = 5e-4
+    warning: float = 1.8
+    critical: float = 3.0
+    fallback: Detector = field(default_factory=ZScoreDetector)
+
+    method = "patchtst"
+
+    def _severity(self, score: float) -> str:
+        if score >= self.critical:
+            return "critical"
+        if score >= self.warning:
+            return "warning"
+        return "normal"
+
+    def detect(
+        self,
+        entity_uid: str,
+        metric_name: str,
+        values: Sequence[float],
+        ts: int,
+        labels: dict | None = None,
+    ) -> SignalRecord:
+        v = np.asarray(values, dtype=np.float32)
+        if len(v) >= self.context_length + self.prediction_length:
+            try:
+                return self._detect_patchtst(entity_uid, metric_name, v, ts, labels)
+            except Exception as exc:  # pragma: no cover - defensive
+                log.warning("PatchTST detect failed (%s); falling back to z-score", exc)
+        return self.fallback.detect(entity_uid, metric_name, values, ts, labels)
+
+    def _detect_patchtst(
+        self,
+        entity_uid: str,
+        metric_name: str,
+        v: np.ndarray,
+        ts: int,
+        labels: dict | None,
+    ) -> SignalRecord:
+        import torch
+        from transformers import PatchTSTConfig, PatchTSTForPrediction
+
+        mu = float(v.mean())
+        sigma = float(v.std()) or 1.0
+        norm = (v - mu) / sigma
+
+        split = max(self.context_length, int(len(norm) * 0.80))
+        windows = _sliding_windows(norm[:split], self.context_length, self.prediction_length)
+        if not windows:
+            return self.fallback.detect(entity_uid, metric_name, v, ts, labels)
+
+        config = PatchTSTConfig(
+            num_input_channels=1,
+            context_length=self.context_length,
+            patch_length=self.patch_length,
+            stride=self.patch_length,
+            prediction_length=self.prediction_length,
+            d_model=self.d_model,
+            num_attention_heads=self.num_heads,
+            num_hidden_layers=self.num_layers,
+            ffn_dim=self.d_model * 4,
+            dropout=0.1,
+            head_dropout=0.0,
+            pooling_type=None,
+            channel_attention=False,
+            scaling="std",
+            loss="mse",
+            pre_norm=True,
+        )
+        model = PatchTSTForPrediction(config)
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
+        model.train()
+        for _ in range(self.epochs):
+            for ctx, tgt in windows:
+                optimizer.zero_grad()
+                past = torch.from_numpy(ctx).float().unsqueeze(0).unsqueeze(-1)
+                future = torch.from_numpy(tgt).float().unsqueeze(0).unsqueeze(-1)
+                model(past_values=past, future_values=future).loss.backward()
+                optimizer.step()
+
+        model.eval()
+        start = len(norm) - self.context_length - self.prediction_length
+        ctx = norm[start : start + self.context_length]
+        tgt = norm[start + self.context_length : start + self.context_length + self.prediction_length]
+        with torch.no_grad():
+            past = torch.from_numpy(ctx).float().unsqueeze(0).unsqueeze(-1)
+            pred = model(past_values=past).prediction_outputs.squeeze().numpy()
+
+        eval_rmse = float(np.sqrt(np.mean((pred - tgt) ** 2)))
+        baseline = _baseline_rmse(model, windows[-5:], torch)
+        score = eval_rmse / max(baseline, 1e-8)
+
+        return SignalRecord(
+            entity_uid=entity_uid,
+            metric_name=metric_name,
+            ts=ts,
+            severity=self._severity(score),
+            score=round(float(score), 4),
+            method=self.method,
+            n_points=int(len(v)),
+            labels=dict(labels or {}),
+        )
+
+
+def _baseline_rmse(model, windows, torch) -> float:
+    errors: list[float] = []
+    model.eval()
+    for ctx, tgt in windows:
+        with torch.no_grad():
+            past = torch.from_numpy(ctx).float().unsqueeze(0).unsqueeze(-1)
+            pred = model(past_values=past).prediction_outputs.squeeze().numpy()
+        errors.append(float(np.sqrt(np.mean((pred - tgt) ** 2))))
+    return float(np.mean(errors)) if errors else 1.0

--- a/detection/reconstruction.py
+++ b/detection/reconstruction.py
@@ -1,0 +1,149 @@
+"""PatchTST reconstruction detector (decision D1, detective face).
+
+Trains a self-supervised PatchTST (masked-patch reconstruction) on the early
+part of a signal, then scores the recent window by reconstruction error relative
+to the model's own baseline error:
+
+    score = eval_recon_error / baseline_recon_error      (method="patchtst-recon")
+    score >= warning -> warning ; >= critical -> critical
+
+This is the detective face of D1: a model that learned to reconstruct *normal*
+patterns reconstructs an out-of-distribution (broken) window poorly, so the error
+spikes cleanly — unlike the forecaster, which degrades under regime change. Short
+signals fall back to z-score. Plugs in behind the ``Detector`` interface.
+
+torch / transformers are imported lazily inside ``detect`` so the package imports
+without them.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Sequence
+
+import numpy as np
+
+from kb.signal import SignalRecord
+
+from .detector import Detector, ZScoreDetector
+
+log = logging.getLogger(__name__)
+
+
+def _recon_windows(signal: np.ndarray, context_length: int) -> list[np.ndarray]:
+    step = max(1, context_length // 4)
+    return [
+        signal[i : i + context_length].copy()
+        for i in range(0, len(signal) - context_length + 1, step)
+    ]
+
+
+@dataclass
+class ReconstructionDetector(Detector):
+    context_length: int = 64
+    patch_length: int = 8
+    d_model: int = 32
+    num_heads: int = 4
+    num_layers: int = 2
+    epochs: int = 30
+    lr: float = 5e-4
+    mask_ratio: float = 0.4
+    warning: float = 1.8
+    critical: float = 3.0
+    fallback: Detector = field(default_factory=ZScoreDetector)
+
+    method = "patchtst-recon"
+
+    def _severity(self, score: float) -> str:
+        if score >= self.critical:
+            return "critical"
+        if score >= self.warning:
+            return "warning"
+        return "normal"
+
+    def detect(
+        self,
+        entity_uid: str,
+        metric_name: str,
+        values: Sequence[float],
+        ts: int,
+        labels: dict | None = None,
+    ) -> SignalRecord:
+        v = np.asarray(values, dtype=np.float32)
+        if len(v) >= self.context_length:
+            try:
+                return self._detect_recon(entity_uid, metric_name, v, ts, labels)
+            except Exception as exc:  # pragma: no cover - defensive
+                log.warning("recon detect failed (%s); falling back to z-score", exc)
+        return self.fallback.detect(entity_uid, metric_name, values, ts, labels)
+
+    def _detect_recon(
+        self,
+        entity_uid: str,
+        metric_name: str,
+        v: np.ndarray,
+        ts: int,
+        labels: dict | None,
+    ) -> SignalRecord:
+        import torch
+        from transformers import PatchTSTConfig, PatchTSTForPretraining
+
+        mu = float(v.mean())
+        sigma = float(v.std()) or 1.0
+        norm = (v - mu) / sigma
+
+        split = max(self.context_length, int(len(norm) * 0.80))
+        # entry guard (len >= context_length) ⇒ split >= context_length ⇒ ≥1 window
+        windows = _recon_windows(norm[:split], self.context_length)
+
+        config = PatchTSTConfig(
+            num_input_channels=1,
+            context_length=self.context_length,
+            patch_length=self.patch_length,
+            stride=self.patch_length,
+            d_model=self.d_model,
+            num_attention_heads=self.num_heads,
+            num_hidden_layers=self.num_layers,
+            ffn_dim=self.d_model * 4,
+            dropout=0.1,
+            mask_type="random",
+            random_mask_ratio=self.mask_ratio,
+            scaling="std",
+        )
+        model = PatchTSTForPretraining(config)
+        optimizer = torch.optim.Adam(model.parameters(), lr=self.lr)
+
+        model.train()
+        for _ in range(self.epochs):
+            for ctx in windows:
+                optimizer.zero_grad()
+                past = torch.from_numpy(ctx).float().unsqueeze(0).unsqueeze(-1)
+                model(past_values=past).loss.backward()
+                optimizer.step()
+
+        model.eval()
+        baseline = _recon_loss(model, windows[-5:], torch)
+        eval_ctx = norm[-self.context_length :]
+        eval_loss = _recon_loss(model, [eval_ctx], torch)
+        score = eval_loss / max(baseline, 1e-8)
+
+        return SignalRecord(
+            entity_uid=entity_uid,
+            metric_name=metric_name,
+            ts=ts,
+            severity=self._severity(score),
+            score=round(float(score), 4),
+            method=self.method,
+            n_points=int(len(v)),
+            labels=dict(labels or {}),
+        )
+
+
+def _recon_loss(model, windows, torch) -> float:
+    losses: list[float] = []
+    model.eval()
+    for ctx in windows:
+        with torch.no_grad():
+            past = torch.from_numpy(ctx).float().unsqueeze(0).unsqueeze(-1)
+            losses.append(float(model(past_values=past).loss))
+    return float(np.mean(losses)) if losses else 1.0

--- a/detection/regime.py
+++ b/detection/regime.py
@@ -1,0 +1,81 @@
+"""RegimeSwitchDetector — composes the two faces of D1 into one verdict.
+
+A per-(entity, metric) state machine decides which face drives the signal:
+
+    NORMAL    forecast face (anticipation)
+       │  forecast severity == critical (a break: forecaster residual spikes)
+       ▼
+    INCIDENT  reconstruction face (detective — the clean OOD signal)
+       │  reconstruction severity == normal (recovery)
+       ▼
+    NORMAL
+
+Only one face runs per call (cheap). The emitted SignalRecord keeps the running
+face's ``method`` (``patchtst`` / ``patchtst-recon`` / ``zscore``) and is annotated
+with ``labels["mode"]`` (anticipation|detective) and ``labels["regime"]`` (the
+regime after this assessment).
+
+State note: the regime is held in a pluggable ``RegimeState`` (in-memory by
+default). Within a long-lived/streaming run this works directly; for separate
+batch runs (e.g. a K3s CronJob) the regime should be seeded from the knowledge
+base (the last signal's ``labels["regime"]``) — a deployment follow-up.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Sequence
+
+from kb.signal import SignalRecord
+
+from .detector import Detector
+
+
+class InMemoryRegimeState:
+    """Per-key regime store. Default 'normal'."""
+
+    def __init__(self) -> None:
+        self._state: dict[tuple[str, str], str] = {}
+
+    def get(self, key: tuple[str, str]) -> str:
+        return self._state.get(key, "normal")
+
+    def set(self, key: tuple[str, str], regime: str) -> None:
+        self._state[key] = regime
+
+
+@dataclass
+class RegimeSwitchDetector(Detector):
+    forecast: Detector       # anticipation face (NORMAL)
+    detective: Detector      # reconstruction face (INCIDENT)
+    state: InMemoryRegimeState = field(default_factory=InMemoryRegimeState)
+
+    method = "regime-switch"
+
+    def detect(
+        self,
+        entity_uid: str,
+        metric_name: str,
+        values: Sequence[float],
+        ts: int,
+        labels: dict | None = None,
+    ) -> SignalRecord:
+        key = (entity_uid, metric_name)
+        regime = self.state.get(key)
+
+        if regime == "normal":
+            sig = self.forecast.detect(entity_uid, metric_name, values, ts, labels)
+            mode = "anticipation"
+            # a break: the forecaster residual spikes to critical → switch to
+            # the detective face for the accurate read next time.
+            next_regime = "incident" if sig.severity == "critical" else "normal"
+        else:  # incident
+            sig = self.detective.detect(entity_uid, metric_name, values, ts, labels)
+            mode = "detective"
+            # recovery: reconstruction error back to baseline.
+            next_regime = "normal" if sig.severity == "normal" else "incident"
+
+        self.state.set(key, next_regime)
+        return replace(
+            sig,
+            labels={**sig.labels, "mode": mode, "regime": next_regime},
+        )

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -95,12 +95,16 @@ Implemented today:
   matching kube-verdict's `zscore` method and severity bands;
 - `PatchTSTDetector` — the **forecast face** of D1: trains a small PatchTST
   (HF `transformers`) on the early signal and scores the recent window by
-  forecast-error ratio (`method="patchtst"`), falling back to z-score for short
-  signals. torch/transformers are optional, lazy-imported.
+  forecast-error ratio (`method="patchtst"`);
+- `ReconstructionDetector` — the **detective face** of D1: trains a
+  self-supervised PatchTST (masked-patch reconstruction) and scores by
+  reconstruction-error ratio (`method="patchtst-recon"`), the clean OOD signal
+  during a break.
 
-The **reconstruction face** (detective) and the NORMAL↔INCIDENT regime switch
-remain the target, behind the same `Detector` interface. The write path is wired
-through the SPI: `MimirSource → make_detection_transform(detector) →
+Both fall back to z-score for short signals; torch/transformers are optional,
+lazy-imported. The **NORMAL↔INCIDENT regime switch** that composes the two faces
+remains the target, behind the same `Detector` interface. The write path is
+wired through the SPI: `MimirSource → make_detection_transform(detector) →
 signal-store sink`, runnable on `LocalEngine` (the K3s demo) or `BeamEngine`.
 
 ## Connector SPI — open to N plugins

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -101,11 +101,18 @@ Implemented today:
   reconstruction-error ratio (`method="patchtst-recon"`), the clean OOD signal
   during a break.
 
-Both fall back to z-score for short signals; torch/transformers are optional,
-lazy-imported. The **NORMAL↔INCIDENT regime switch** that composes the two faces
-remains the target, behind the same `Detector` interface. The write path is
-wired through the SPI: `MimirSource → make_detection_transform(detector) →
-signal-store sink`, runnable on `LocalEngine` (the K3s demo) or `BeamEngine`.
+- `RegimeSwitchDetector` — composes the two faces into D1's state machine:
+  forecast in NORMAL (anticipation), reconstruction in INCIDENT (detective),
+  switching to INCIDENT on a break (forecast residual → critical) and back on
+  recovery. Emits `labels["mode"]` (anticipation|detective) and
+  `labels["regime"]`; per-(entity, metric) state via a pluggable `RegimeState`.
+
+Detectors fall back to z-score for short signals; torch/transformers are
+optional, lazy-imported. **D1 is implemented end-to-end.** (Refinements left:
+anti-flapping/hysteresis on recovery, and seeding the regime from the knowledge
+base across separate batch runs.) The write path is wired through the SPI:
+`MimirSource → make_detection_transform(detector) → signal-store sink`, runnable
+on `LocalEngine` (the K3s demo) or `BeamEngine`.
 
 ## Connector SPI — open to N plugins
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,9 +2,10 @@
 
 ## Goal
 
-Consolidate K8s metrics into a sovereign datalake and detect variations
-(anomalies / drift) on time-series using PatchTST, with unified batch and
-streaming processing.
+Consolidate K8s metrics into a datalake and detect variations (anomalies /
+drift) on time-series using PatchTST, with unified batch and streaming
+processing. The design is provider-agnostic — deployment target (managed cloud,
+self-hosted, or sovereign) is a configuration choice, not baked into the core.
 
 ## Core principle
 
@@ -12,44 +13,90 @@ The processing core (windowing → PatchTST inference → variation detection)
 never knows where data comes from or goes to. Sources and sinks are **plugins**
 behind a stable contract. Apache Beam is the engine because the same pipeline
 runs in batch (replay history) and streaming (live ingestion), and is portable
-across runners (DirectRunner for dev, Flink/Spark on-cluster for sovereign prod).
+across runners (DirectRunner for dev, Flink/Spark on-cluster or Dataflow for prod).
 
-## Target flow (sovereign stack)
+## Reference flow
+
+The boxes below are *roles*, each filled by an interchangeable connector. The
+names in parentheses are one possible instantiation; any backend that implements
+the SPI role can be substituted (see [CONNECTORS.md](./CONNECTORS.md)).
 
 ```
 Agents (Prometheus / OTEL)
         │  remote-write
         ▼
-   Grafana Mimir  ◄──── metric blocks ────►  MinIO (S3)
-        │  PromQL query_range                      ▲
-        ▼                                          │
-   Beam / Flink  (windowing)                       │
-        │                                          │
-        ▼                                          │
-   PatchTST inference (reconstruction error)       │
-        │                                          │
-        ▼                                          │
-   Variation detection                             │
-        │                                          │
-        ├──► Iceberg datalake ────────────────────┘  (same MinIO substrate)
-        ├──► ClickHouse (analytics)
-        └──► KubeVerdict (alerting / verdict)
+   metrics store  ◄──── blocks ────►  object store (S3 API)
+   (e.g. Mimir)                            ▲
+        │  query / pull                    │
+        ▼                                  │
+   Beam runner  (windowing)                │
+   (Direct / Flink / Spark / Dataflow)     │
+        │                                  │
+        ▼                                  │
+   PatchTST inference (forecast ⇄ reconstruction)
+        │                                  │
+        ▼                                  │
+   Variation detection                     │
+        │                                  │
+        ├──► datalake (table format) ──────┘  (same object-store substrate)
+        ├──► analytics store
+        └──► alerting / verdict sink
 ```
 
-MinIO is the single object-storage substrate, backing both Mimir blocks and the
-Iceberg datalake — one storage layer to secure, back up, and keep sovereign.
+A single object store (any S3-compatible backend) can serve as the substrate for
+both the metrics store's blocks and the datalake — one storage layer to secure
+and back up, whichever provider you choose.
 
 ## Detection mechanism
 
-Default: **self-supervised reconstruction error** (`PatchTST_self_supervised`).
-The model reconstructs masked patches; the gap between reconstruction and actual
-value is the variation signal. This needs no labels and gives a clean reactive
-signal. The forecast-plus-residual path remains an alternative (decision D1).
+**Decided (D1): dual detector, regime-switching.** Two signals on one PatchTST
+pipeline, each used where it is reliable:
+
+- **Forecast — anticipation** (`PatchTST_supervised`). In the normal/trending
+  regime the model forecasts the trajectory; a predicted threshold crossing
+  within horizon `h` raises an early **WARN**. This is the "see the wall coming"
+  path, scoped to slow-saturation metrics (disk, memory, quota, latency drift).
+- **Reconstruction — detective** (`PatchTST_self_supervised`). A brutal break
+  pushes the input out-of-distribution, where the forecaster collapses (its
+  predictions become unreliable exactly when needed). Reconstruction error spikes
+  cleanly on OOD input, so at the break the verdict switches to this signal — no
+  waiting for `actual[t+h]`.
+
+**Why both, not one.** It is not a compromise but the technically correct split:
+forecast is accurate pre-break and buys lead time; reconstruction is the clean
+signal during the incident *because* forecast degrades under regime change.
+
+**State machine per `group_id`:**
+
+```
+NORMAL  ──(break: reconstruction error spikes)──►  INCIDENT
+   ▲                                                   │
+   └──────────(recovery: error back to baseline)───────┘
+
+NORMAL   : forecast drives anticipation (early WARN)
+INCIDENT : reconstruction drives the verdict; anticipation suspended (model OOD)
+```
+
+**Design constraint:** anticipation only pays if it is actionable — the horizon
+`h` must be ≤ the remediation time (autoscale / drain / page), otherwise an early
+WARN is cosmetic and detective alone is preferable.
 
 ## Connector SPI — open to N plugins
 
 Connectors are not architecture decisions, they are interchangeable
 implementations of one contract.
+
+**Decided (D4): native multivariate pivot.** A row carries an aligned vector of
+channel values at one timestamp:
+`{group_id: str, ts: int, values: tuple[float], channels: tuple[str], labels: dict}`.
+
+Intentional model mismatch, accepted with eyes open: PatchTST is
+**channel-independent** — it processes each channel as an independent univariate
+sequence with no cross-channel attention. So the grouping buys batching and a
+group-level detection decision, **not** joint modeling of cross-channel
+correlation. The real cost of multivariate — temporal alignment of
+heterogeneous K8s cadences onto a common grid — is paid inside the source
+connector (`connectors/alignment.py`), never in the core.
 
 ```python
 # connectors/base.py
@@ -57,7 +104,7 @@ from abc import ABC, abstractmethod
 import apache_beam as beam
 
 # Pivot schema — the only language the core understands:
-# {series_id: str, ts: int, value: float, labels: dict}
+# {group_id: str, ts: int, values: tuple[float], channels: tuple[str], labels: dict}
 
 class SourceConnector(ABC):
     @abstractmethod
@@ -96,20 +143,19 @@ p | src.read() | Window() | RunInference(patchtst) | Detect() | *[s.write() for 
 Adding a connector = dropping one file with `@connector("name")`. The core and
 the pipeline never change. That openness is the point of having N connectors.
 
-## Sovereignty model
+## Deployment is independent of design
 
-Three tiers, to be explicit about what "sovereign" means here:
+The architecture is provider-agnostic: *where* it runs is a deployment choice
+layered on top, not a property of the core or the SPI. The same pipeline runs
+against a managed cloud, a self-hosted OSS stack, or a sovereign/EU provider by
+swapping connector config and the runner flag — no code change. See the
+deployment profiles in [CONNECTORS.md](./CONNECTORS.md).
 
-- **SecNumCloud-qualified** (OVHcloud select offers, Outscale/Dassault, Cloud
-  Temple): French/EU law, immune to extra-territorial reach.
-- **"Trusted cloud" but US tech under license** (S3NS = Thales+Google, Bleu =
-  Capgemini/Orange+Microsoft): excluded if strict immunity is the goal.
-- **Open-source self-hosted** (MinIO, Ceph, ClickHouse, Kafka, Mimir): maximum
-  sovereignty since we control the substrate; the operational debt is ours.
-
-Sovereignty is not only runtime: a data catalog (Nessie/Polaris) and lineage
-(OpenMetadata/DataHub) matter too, because proving *where data lives and who
-accesses it* is part of SecNumCloud / GDPR requirements.
+Each profile carries its own trade-offs (managed convenience vs operational
+debt, jurisdiction/compliance, cost). Sovereignty — e.g. SecNumCloud-qualified
+providers with no extra-territorial exposure, plus catalog/lineage to prove
+*where data lives and who accesses it* — is one such profile, selectable when
+required, never assumed.
 
 See [CONNECTORS.md](./CONNECTORS.md) for the plugin catalog and
 [ROADMAP.md](./ROADMAP.md) for milestones and open decisions.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,9 +2,17 @@
 
 ## Goal
 
-Consolidate K8s metrics into a datalake and detect variations (anomalies /
-drift) on time-series using PatchTST, with unified batch and streaming
-processing. The design is provider-agnostic — deployment target (managed cloud,
+Aggregate time-series **signals** into a datalake and detect variations
+(anomalies / drift) using PatchTST, with unified batch and streaming processing.
+
+The core is **domain-agnostic**: it knows only generic signals — an entity, a
+metric, values over time (`PivotRow` / `SignalRecord` carry no domain-specific
+field). It therefore serves any time-series domain (infrastructure, IoT,
+application or business KPIs, …). **Kubernetes observability — feeding
+[kube-verdict](https://github.com/a1h8/kube-verdict) — is the reference
+application, not a constraint.**
+
+The design is also **provider-agnostic**: deployment target (managed cloud,
 self-hosted, or sovereign) is a configuration choice, not baked into the core.
 
 ## Core principle
@@ -170,6 +178,48 @@ portable without sacrificing engine-native streaming where it matters.
 Trade-off (accepted): "plug any engine" is not free — each engine needs its
 adapter, and engine-native features are not portable for nothing. But the core,
 connectors, and detection logic are written once, engine-free.
+
+## Knowledge base — feeding kube-verdict (D7)
+
+This pipeline is the **signal-aggregation / knowledge-base layer** for
+[kube-verdict](https://github.com/a1h8/kube-verdict), an evidence-first K8s
+incident decision engine. The two are complementary, not duplicative:
+
+| | kube-verdict | this pipeline |
+|---|---|---|
+| When | reactive, per incident | continuous |
+| Scope | one entity in RCA | cluster-wide, longitudinal |
+| Output | point-in-time verdict / RCA | queryable **signal history** |
+
+We do **not** re-implement detection — kube-verdict already has
+`signals/patchtst_detector.py`. Our value is aggregating signals over time into a
+**queryable knowledge base** kube-verdict draws on as historical evidence.
+
+**Structured face (`kb/`, implemented).** Aggregated `SignalRecord`s (schema
+aligned with kube-verdict's `AnomalyResult`) are written as Parquet and queried
+by DuckDB. The store exposes the contract kube-verdict's `rca/context_builder`
+calls during RCA:
+
+```
+GET /api/v1/signals/history?entity=Pod/prod/api&metric=cpu_usage&since=..&until=..
+```
+
+This is "interrogate the service with a signal" — decoupled, touching neither
+kube-verdict's embedder nor its FAISS index. Backend is Parquet+DuckDB now
+(S3/Iceberg-ready), swappable for ClickHouse at scale behind the same interface.
+
+**Semantic face (planned).** A parallel vector store (Weaviate as a shared
+service, owning its vectorizer) for kube-verdict's RAG `example_lookup_node`.
+Kept separate from the structured face to avoid coupling to its hardcoded
+`all-MiniLM-L6-v2` FAISS index.
+
+**Write path goes through the SPI** — the store is exposed as a
+`@connector("signal-store")` `SinkConnector`, so signals are written via the
+normal connector cycle (`build → Engine.run → sink.write`), not a standalone
+write. **Read path** (`SignalStore.query` / the HTTP service) stays *outside*
+the SPI on purpose: it is request/response serving, not streaming dataflow.
+Optional secondary push: emit Alertmanager-format alerts to
+`/api/v1/webhook/alertmanager` to trigger RCA.
 
 ## Deployment is independent of design
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,12 +90,18 @@ INCIDENT : reconstruction drives the verdict; anticipation suspended (model OOD)
 WARN is cosmetic and detective alone is preferable.
 
 **Implementation status.** Detection is a pluggable `Detector` (`detection/`).
-Implemented today: `ZScoreDetector` — real statistical detection (z-score on the
-recent tail), matching kube-verdict's `zscore` method and severity bands. The
-PatchTST dual-detector above is the target and slots in behind the same
-interface without touching the pipeline. The write path is wired through the
-SPI: `MimirSource → make_detection_transform(detector) → signal-store sink`,
-runnable on `LocalEngine` (the K3s demo) or `BeamEngine`.
+Implemented today:
+- `ZScoreDetector` — real statistical detection (z-score on the recent tail),
+  matching kube-verdict's `zscore` method and severity bands;
+- `PatchTSTDetector` — the **forecast face** of D1: trains a small PatchTST
+  (HF `transformers`) on the early signal and scores the recent window by
+  forecast-error ratio (`method="patchtst"`), falling back to z-score for short
+  signals. torch/transformers are optional, lazy-imported.
+
+The **reconstruction face** (detective) and the NORMAL↔INCIDENT regime switch
+remain the target, behind the same `Detector` interface. The write path is wired
+through the SPI: `MimirSource → make_detection_transform(detector) →
+signal-store sink`, runnable on `LocalEngine` (the K3s demo) or `BeamEngine`.
 
 ## Connector SPI — open to N plugins
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,6 +89,14 @@ INCIDENT : reconstruction drives the verdict; anticipation suspended (model OOD)
 `h` must be ≤ the remediation time (autoscale / drain / page), otherwise an early
 WARN is cosmetic and detective alone is preferable.
 
+**Implementation status.** Detection is a pluggable `Detector` (`detection/`).
+Implemented today: `ZScoreDetector` — real statistical detection (z-score on the
+recent tail), matching kube-verdict's `zscore` method and severity bands. The
+PatchTST dual-detector above is the target and slots in behind the same
+interface without touching the pipeline. The write path is wired through the
+SPI: `MimirSource → make_detection_transform(detector) → signal-store sink`,
+runnable on `LocalEngine` (the K3s demo) or `BeamEngine`.
+
 ## Connector SPI — open to N plugins
 
 Connectors are not architecture decisions, they are interchangeable

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -98,23 +98,28 @@ correlation. The real cost of multivariate — temporal alignment of
 heterogeneous K8s cadences onto a common grid — is paid inside the source
 connector (`connectors/alignment.py`), never in the core.
 
+The contract is **engine-agnostic** (decision D6): a source *yields* rows, a sink
+*consumes* them — no execution engine appears in the contract.
+
 ```python
-# connectors/base.py
+# connectors/base.py — no engine import
 from abc import ABC, abstractmethod
-import apache_beam as beam
+from typing import Iterable
 
 # Pivot schema — the only language the core understands:
 # {group_id: str, ts: int, values: tuple[float], channels: tuple[str], labels: dict}
 
 class SourceConnector(ABC):
     @abstractmethod
-    def read(self) -> beam.PTransform:   # -> PCollection[PivotRow]
+    def read(self) -> Iterable[PivotRow]:        # pure Python
         ...
+    def native_beam_read(self): return None      # optional engine-native override
 
 class SinkConnector(ABC):
     @abstractmethod
-    def write(self) -> beam.PTransform:  # PCollection -> writes out
+    def write(self, rows: Iterable) -> None:      # pure Python
         ...
+    def native_beam_write(self): return None      # optional engine-native override
 ```
 
 ```python
@@ -131,17 +136,40 @@ def build(name: str, **cfg):
     return _REGISTRY[name](**cfg)
 ```
 
-The pipeline is config-driven and source/sink agnostic:
-
-```python
-src = build(cfg.source.type, **cfg.source.params)
-sinks = [build(s.type, **s.params) for s in cfg.sinks]
-
-p | src.read() | Window() | RunInference(patchtst) | Detect() | *[s.write() for s in sinks]
-```
-
 Adding a connector = dropping one file with `@connector("name")`. The core and
 the pipeline never change. That openness is the point of having N connectors.
+
+## Execution engines — ports & adapters (D6)
+
+The core and connectors are engine-agnostic; an **engine adapter** runs a
+`source → sinks` flow on a concrete runtime. The engine depends on connectors,
+never the reverse — the hexagonal boundary that lets the system plug into any
+engine.
+
+```
+core (PivotRow, connectors, detection)  ── engine-agnostic
+    │
+    ├─ engines/local.py   pure Python — no third-party dep (dev, tests, small jobs)
+    ├─ engines/beam.py    Apache Beam (current production path)
+    └─ engines/spark.py   Spark / Databricks (planned, "one engine among others")
+```
+
+```python
+src   = build(cfg.source.type, **cfg.source.params)
+sinks = [build(s.type, **s.params) for s in cfg.sinks]
+
+LocalEngine().run(src, sinks)   # or BeamEngine().run(src, sinks)
+```
+
+**Native capability hook.** A pure iterator cannot express an engine's native
+distributed/unbounded I/O (unbounded Kafka, a parallel writer). A connector may
+expose `native_beam_read` / `native_beam_write`; the engine adapter uses them
+when present and falls back to gather-and-call otherwise. This keeps connectors
+portable without sacrificing engine-native streaming where it matters.
+
+Trade-off (accepted): "plug any engine" is not free — each engine needs its
+adapter, and engine-native features are not portable for nothing. But the core,
+connectors, and detection logic are written once, engine-free.
 
 ## Deployment is independent of design
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,115 @@
+# Architecture — Metrics Variation Detection on PatchTST
+
+## Goal
+
+Consolidate K8s metrics into a sovereign datalake and detect variations
+(anomalies / drift) on time-series using PatchTST, with unified batch and
+streaming processing.
+
+## Core principle
+
+The processing core (windowing → PatchTST inference → variation detection)
+never knows where data comes from or goes to. Sources and sinks are **plugins**
+behind a stable contract. Apache Beam is the engine because the same pipeline
+runs in batch (replay history) and streaming (live ingestion), and is portable
+across runners (DirectRunner for dev, Flink/Spark on-cluster for sovereign prod).
+
+## Target flow (sovereign stack)
+
+```
+Agents (Prometheus / OTEL)
+        │  remote-write
+        ▼
+   Grafana Mimir  ◄──── metric blocks ────►  MinIO (S3)
+        │  PromQL query_range                      ▲
+        ▼                                          │
+   Beam / Flink  (windowing)                       │
+        │                                          │
+        ▼                                          │
+   PatchTST inference (reconstruction error)       │
+        │                                          │
+        ▼                                          │
+   Variation detection                             │
+        │                                          │
+        ├──► Iceberg datalake ────────────────────┘  (same MinIO substrate)
+        ├──► ClickHouse (analytics)
+        └──► KubeVerdict (alerting / verdict)
+```
+
+MinIO is the single object-storage substrate, backing both Mimir blocks and the
+Iceberg datalake — one storage layer to secure, back up, and keep sovereign.
+
+## Detection mechanism
+
+Default: **self-supervised reconstruction error** (`PatchTST_self_supervised`).
+The model reconstructs masked patches; the gap between reconstruction and actual
+value is the variation signal. This needs no labels and gives a clean reactive
+signal. The forecast-plus-residual path remains an alternative (decision D1).
+
+## Connector SPI — open to N plugins
+
+Connectors are not architecture decisions, they are interchangeable
+implementations of one contract.
+
+```python
+# connectors/base.py
+from abc import ABC, abstractmethod
+import apache_beam as beam
+
+# Pivot schema — the only language the core understands:
+# {series_id: str, ts: int, value: float, labels: dict}
+
+class SourceConnector(ABC):
+    @abstractmethod
+    def read(self) -> beam.PTransform:   # -> PCollection[PivotRow]
+        ...
+
+class SinkConnector(ABC):
+    @abstractmethod
+    def write(self) -> beam.PTransform:  # PCollection -> writes out
+        ...
+```
+
+```python
+# connectors/registry.py
+_REGISTRY: dict[str, type] = {}
+
+def connector(name: str):
+    def deco(cls):
+        _REGISTRY[name] = cls
+        return cls
+    return deco
+
+def build(name: str, **cfg):
+    return _REGISTRY[name](**cfg)
+```
+
+The pipeline is config-driven and source/sink agnostic:
+
+```python
+src = build(cfg.source.type, **cfg.source.params)
+sinks = [build(s.type, **s.params) for s in cfg.sinks]
+
+p | src.read() | Window() | RunInference(patchtst) | Detect() | *[s.write() for s in sinks]
+```
+
+Adding a connector = dropping one file with `@connector("name")`. The core and
+the pipeline never change. That openness is the point of having N connectors.
+
+## Sovereignty model
+
+Three tiers, to be explicit about what "sovereign" means here:
+
+- **SecNumCloud-qualified** (OVHcloud select offers, Outscale/Dassault, Cloud
+  Temple): French/EU law, immune to extra-territorial reach.
+- **"Trusted cloud" but US tech under license** (S3NS = Thales+Google, Bleu =
+  Capgemini/Orange+Microsoft): excluded if strict immunity is the goal.
+- **Open-source self-hosted** (MinIO, Ceph, ClickHouse, Kafka, Mimir): maximum
+  sovereignty since we control the substrate; the operational debt is ours.
+
+Sovereignty is not only runtime: a data catalog (Nessie/Polaris) and lineage
+(OpenMetadata/DataHub) matter too, because proving *where data lives and who
+accesses it* is part of SecNumCloud / GDPR requirements.
+
+See [CONNECTORS.md](./CONNECTORS.md) for the plugin catalog and
+[ROADMAP.md](./ROADMAP.md) for milestones and open decisions.

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -2,70 +2,85 @@
 
 Connectors implement the SPI defined in [ARCHITECTURE.md](./ARCHITECTURE.md):
 `SourceConnector.read()` and `SinkConnector.write()`, both speaking the pivot
-schema `{series_id, ts, value, labels}`. Each connector is a plugin registered
-with `@connector("name")`; the core never depends on a concrete connector.
+schema `{group_id, ts, values[], channels[], labels}`. Each connector is a plugin
+registered with `@connector("name")`; the core never depends on a concrete
+connector.
 
-The catalog below is oriented toward a sovereign cloud (no US hyperscaler), but
-any connector that satisfies the contract and passes the conformance suite can
-be added.
+**The SPI is provider-agnostic.** A connector is just an implementation of the
+contract — it can target a managed cloud service, a self-hosted OSS system, or a
+sovereign provider. The catalog below is grouped by *function*; within each
+function the backends are interchangeable, and none is privileged. Pick whichever
+fits your environment; the pipeline code does not change.
 
-## Sources
+## Sources — metrics ingestion
 
-| ID  | Plugin | Mechanism | Replaces (GCP) | Sovereignty / Note |
-|-----|--------|-----------|----------------|--------------------|
-| C9a | **Grafana Mimir** | remote-write in + PromQL read | — | OSS (AGPLv3) · blocks on MinIO · multi-tenant, single entry point |
-| C1  | Prometheus PromQL | `query_range` | — | OSS · typically points at Mimir |
-| C2  | OTLP / remote-write | live push | — | OSS, vendor-neutral |
-| C7  | Kafka / Redpanda | streaming bus | PubSub | OSS self-hosted · Redpanda lighter, no ZooKeeper |
-| C8  | NATS JetStream | streaming bus | PubSub | OSS · low footprint, edge-friendly |
-| C10 | VictoriaMetrics | TSDB read/write | — | OSS · compact Thanos/Mimir alternative |
+| ID  | Plugin | Mechanism | Note |
+|-----|--------|-----------|------|
+| C9a | **Grafana Mimir** | remote-write in + PromQL read | multi-tenant, single entry point, blocks on object storage |
+| C1  | Prometheus | PromQL `query_range` | direct scrape target or long-term store front-end |
+| C2  | OTLP / remote-write | live push | vendor-neutral OpenTelemetry |
+| C7  | Kafka / Redpanda | streaming bus | Redpanda lighter, no ZooKeeper |
+| C8  | NATS JetStream | streaming bus | low footprint, edge-friendly |
+| C10 | VictoriaMetrics | TSDB read/write | compact TSDB alternative |
+| C23 | Cloud Pub/Sub / Kinesis | managed streaming bus | managed-cloud option |
 
 ## Sinks — object storage / datalake
 
-| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
-|-----|--------|----------------|--------------------|
-| C11 | **MinIO** | GCS | OSS · S3 API · single storage substrate |
-| C12 | Ceph RGW | GCS | OSS · on-prem at scale |
-| C13 | OVHcloud / Scaleway Object Storage | GCS | SecNumCloud (select offers) · EU |
-| C14 | Outscale OOS | GCS | SecNumCloud · Dassault Systèmes |
+All speak the **S3 API**, so a single connector covers every S3-compatible
+backend; the target is a config/credentials concern, not a code change.
+
+| ID  | Plugin | Backend examples |
+|-----|--------|------------------|
+| C11 | **S3-compatible object store** | AWS S3 · GCS (interop) · Azure Blob · MinIO · Ceph RGW · OVHcloud / Scaleway / Outscale |
 
 ## Sinks — analytics / query
 
-| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
-|-----|--------|----------------|--------------------|
-| C15 | **ClickHouse** | BigQuery | OSS · strong on time-series OLAP |
-| C16 | TimescaleDB / PostgreSQL | BigQuery | OSS · for moderate volume |
-| C17 | Trino / DuckDB | BigQuery | OSS · query-on-lake over Parquet/Iceberg |
+| ID  | Plugin | Note |
+|-----|--------|------|
+| C15 | **ClickHouse** | strong on time-series OLAP |
+| C16 | TimescaleDB / PostgreSQL | for moderate volume |
+| C17 | Trino / DuckDB | query-on-lake over Parquet/Iceberg |
+| C24 | BigQuery / Snowflake / Redshift | managed-cloud warehouses |
 
-## Table format, catalog, governance
+## Table format & catalog
 
-| ID  | Plugin | Role | Sovereignty / Note |
-|-----|--------|------|--------------------|
-| C18 | **Apache Iceberg** (on MinIO) | ACID table format, time-travel | OSS · open datalake |
-| C19 | Nessie / Polaris | versioned "git-for-data" catalog | OSS · table governance |
-| C22 | OpenMetadata / DataHub | lineage, governance | OSS · traceability for SecNumCloud/GDPR |
+| ID  | Plugin | Role |
+|-----|--------|------|
+| C18 | **Apache Iceberg** / Delta | ACID table format, time-travel, open datalake |
+| C19 | Nessie / Polaris | versioned "git-for-data" catalog |
+| C22 | OpenMetadata / DataHub | lineage, governance, traceability |
 
 ## Alerting
 
-| ID  | Plugin | Role | Note |
-|-----|--------|------|------|
-| C6  | **KubeVerdict** | emit verdict + context | in-house |
+| ID  | Plugin | Role |
+|-----|--------|------|
+| C6  | **KubeVerdict** | emit verdict + context (in-house) |
+| C25 | Alertmanager / PagerDuty / Opsgenie | standard alert routing |
 
-## Runners (Beam execution, not connectors but sovereignty-relevant)
+## Runners — execution axis (not connectors)
 
-| ID  | Runner | Replaces (GCP) | Note |
-|-----|--------|----------------|------|
-| C20 | Flink on-K8s | Dataflow | OSS · streaming, the J6 operational debt |
-| C21 | Spark on-K8s | Dataflow | OSS · batch, if Spark already in place |
+Runners are the *other* axis: the Beam pipeline is portable, so the runner is a
+`--runner` flag, not connector code. Listed here only for completeness.
 
-## Recommended sovereign stack
+| Runner | Use |
+|--------|-----|
+| DirectRunner | local dev / test |
+| Flink / Spark on-K8s | self-hosted production |
+| Dataflow | managed-cloud production (GCP) |
+
+## Deployment profiles (examples — none privileged)
+
+The same pipeline runs against different stacks by swapping connector config and
+the runner flag:
 
 ```
-Agents → Mimir (C9a) → Beam/Flink (C20) → MinIO+Iceberg (C11/C18)
-       → ClickHouse (C15) → KubeVerdict (C6)
+Managed cloud (GCP):  Pub/Sub → Dataflow → GCS + BigQuery
+Self-hosted (OSS):    Mimir   → Flink    → MinIO + Iceberg → ClickHouse
+Sovereign (EU):       Mimir   → Flink    → OVH/Outscale S3 → ClickHouse
 ```
 
-All OSS, self-hostable on the K8s cluster, zero US-hyperscaler dependency, and
-migratable to a SecNumCloud provider (C13/C14) without touching pipeline code
-thanks to the shared S3 API. MinIO is the single substrate under both Mimir and
-the Iceberg datalake.
+Sovereignty (SecNumCloud-qualified providers, no US-hyperscaler dependency) is
+**one** such profile — selectable, not assumed. Because the object-storage sink
+speaks the S3 API and the runner is a flag, moving between profiles needs no code
+change. The trade-offs that distinguish profiles (managed vs operational debt,
+jurisdiction, cost) are deployment decisions, independent of the SPI.

--- a/docs/CONNECTORS.md
+++ b/docs/CONNECTORS.md
@@ -1,0 +1,71 @@
+# Connectors — Plugin Catalog
+
+Connectors implement the SPI defined in [ARCHITECTURE.md](./ARCHITECTURE.md):
+`SourceConnector.read()` and `SinkConnector.write()`, both speaking the pivot
+schema `{series_id, ts, value, labels}`. Each connector is a plugin registered
+with `@connector("name")`; the core never depends on a concrete connector.
+
+The catalog below is oriented toward a sovereign cloud (no US hyperscaler), but
+any connector that satisfies the contract and passes the conformance suite can
+be added.
+
+## Sources
+
+| ID  | Plugin | Mechanism | Replaces (GCP) | Sovereignty / Note |
+|-----|--------|-----------|----------------|--------------------|
+| C9a | **Grafana Mimir** | remote-write in + PromQL read | — | OSS (AGPLv3) · blocks on MinIO · multi-tenant, single entry point |
+| C1  | Prometheus PromQL | `query_range` | — | OSS · typically points at Mimir |
+| C2  | OTLP / remote-write | live push | — | OSS, vendor-neutral |
+| C7  | Kafka / Redpanda | streaming bus | PubSub | OSS self-hosted · Redpanda lighter, no ZooKeeper |
+| C8  | NATS JetStream | streaming bus | PubSub | OSS · low footprint, edge-friendly |
+| C10 | VictoriaMetrics | TSDB read/write | — | OSS · compact Thanos/Mimir alternative |
+
+## Sinks — object storage / datalake
+
+| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
+|-----|--------|----------------|--------------------|
+| C11 | **MinIO** | GCS | OSS · S3 API · single storage substrate |
+| C12 | Ceph RGW | GCS | OSS · on-prem at scale |
+| C13 | OVHcloud / Scaleway Object Storage | GCS | SecNumCloud (select offers) · EU |
+| C14 | Outscale OOS | GCS | SecNumCloud · Dassault Systèmes |
+
+## Sinks — analytics / query
+
+| ID  | Plugin | Replaces (GCP) | Sovereignty / Note |
+|-----|--------|----------------|--------------------|
+| C15 | **ClickHouse** | BigQuery | OSS · strong on time-series OLAP |
+| C16 | TimescaleDB / PostgreSQL | BigQuery | OSS · for moderate volume |
+| C17 | Trino / DuckDB | BigQuery | OSS · query-on-lake over Parquet/Iceberg |
+
+## Table format, catalog, governance
+
+| ID  | Plugin | Role | Sovereignty / Note |
+|-----|--------|------|--------------------|
+| C18 | **Apache Iceberg** (on MinIO) | ACID table format, time-travel | OSS · open datalake |
+| C19 | Nessie / Polaris | versioned "git-for-data" catalog | OSS · table governance |
+| C22 | OpenMetadata / DataHub | lineage, governance | OSS · traceability for SecNumCloud/GDPR |
+
+## Alerting
+
+| ID  | Plugin | Role | Note |
+|-----|--------|------|------|
+| C6  | **KubeVerdict** | emit verdict + context | in-house |
+
+## Runners (Beam execution, not connectors but sovereignty-relevant)
+
+| ID  | Runner | Replaces (GCP) | Note |
+|-----|--------|----------------|------|
+| C20 | Flink on-K8s | Dataflow | OSS · streaming, the J6 operational debt |
+| C21 | Spark on-K8s | Dataflow | OSS · batch, if Spark already in place |
+
+## Recommended sovereign stack
+
+```
+Agents → Mimir (C9a) → Beam/Flink (C20) → MinIO+Iceberg (C11/C18)
+       → ClickHouse (C15) → KubeVerdict (C6)
+```
+
+All OSS, self-hostable on the K8s cluster, zero US-hyperscaler dependency, and
+migratable to a SecNumCloud provider (C13/C14) without touching pipeline code
+thanks to the shared S3 API. MinIO is the single substrate under both Mimir and
+the Iceberg datalake.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -8,7 +8,7 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) and [CONNECTORS.md](./CONNECTORS.md).
 | Milestone | Deliverable | Priority |
 |-----------|-------------|----------|
 | **M0** | Frozen decisions (D1–D5 below) — gate before any code beyond M2 | ✅ D1/D3/D4 decided |
-| **M1** | PatchTST inference module decoupled from the training `Learner`, exposing **both heads**: `forecast(window)` and `reconstruct(window)`; RevIN normalization, checkpoint loaded once per worker | P0 |
+| **M1** | PatchTST inference module decoupled from the training `Learner`, exposing **both heads**: `forecast(window)` and `reconstruct(window)`; RevIN normalization, checkpoint loaded once per worker — *engine implemented (`inference/`), validated on synthetic checkpoints; real trained checkpoints + detector rebranch pending* | 🟡 engine done |
 | **M1.5** | **Connector SPI**: pivot schema + `SourceConnector`/`SinkConnector` contracts + `registry` + contract/conformance test suite — *implemented (PR #2), 100% coverage* | ✅ done |
 | **M2** | Beam batch skeleton on DirectRunner: source → windowing → sink, no model. Validates pivot schema end-to-end (dev/test only, never prod) | P0 |
 | **M3** | PatchTST in the pipeline via `RunInference` with a custom PyTorch `ModelHandler`: per-worker load, batching, device. Output enriched with **forecast residual + reconstruction error** | P0 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,12 +7,12 @@ See [ARCHITECTURE.md](./ARCHITECTURE.md) and [CONNECTORS.md](./CONNECTORS.md).
 
 | Milestone | Deliverable | Priority |
 |-----------|-------------|----------|
-| **M0** | Frozen decisions (D1–D5 below) — gate before any code beyond M2 | 🔴 blocking |
-| **M1** | PatchTST inference module decoupled from the training `Learner`: `predict(window) -> reconstruction`, RevIN normalization, checkpoint loaded once per worker | P0 |
-| **M1.5** | **Connector SPI**: pivot schema + `SourceConnector`/`SinkConnector` contracts + `registry` + contract/conformance test suite | P0 |
+| **M0** | Frozen decisions (D1–D5 below) — gate before any code beyond M2 | ✅ D1/D3/D4 decided |
+| **M1** | PatchTST inference module decoupled from the training `Learner`, exposing **both heads**: `forecast(window)` and `reconstruct(window)`; RevIN normalization, checkpoint loaded once per worker | P0 |
+| **M1.5** | **Connector SPI**: pivot schema + `SourceConnector`/`SinkConnector` contracts + `registry` + contract/conformance test suite — *implemented (PR #2), 100% coverage* | ✅ done |
 | **M2** | Beam batch skeleton on DirectRunner: source → windowing → sink, no model. Validates pivot schema end-to-end (dev/test only, never prod) | P0 |
-| **M3** | PatchTST in the pipeline via `RunInference` with a custom PyTorch `ModelHandler`: per-worker load, batching, device. Output enriched with reconstruction + error | P0 |
-| **M4** | Variation detection: static thresholding first, then adaptive (rolling quantile / MAD) per `series_id`, plus anti-flapping (hysteresis, debounce) | P0 |
+| **M3** | PatchTST in the pipeline via `RunInference` with a custom PyTorch `ModelHandler`: per-worker load, batching, device. Output enriched with **forecast residual + reconstruction error** | P0 |
+| **M4** | **Regime-switching detection** per `group_id` (NORMAL→INCIDENT state machine): forecast anticipation (early WARN, `h ≤ remediation time`) in NORMAL, reconstruction detective verdict in INCIDENT; adaptive thresholds (rolling quantile / MAD), per-channel residual aggregation, anti-flapping | P0 |
 | **M5** | Streaming: same pipeline unbounded — sliding windows, watermarks, late data, triggering | P1 |
 | **M6** | Production runner (Flink on-K8s or Dataflow) + pipeline monitoring (lag, throughput, failures) | P1 |
 | **M7** | KubeVerdict alerting + optional retraining loop back to the datalake | P2 |
@@ -32,16 +32,18 @@ real value — before investing in streaming ops.
 Once the SPI (M1.5) is frozen, each connector is a small, parallelizable PR:
 drop a file under `connectors/sources/` or `connectors/sinks/` with
 `@connector("name")` and pass the conformance suite. P0 connectors for the POC:
-**Mimir (C9a)** source and **MinIO/Iceberg (C11/C18)** sink.
+a metrics source (**Mimir, C9a**) and an **object-store + table-format** sink
+(**S3 API + Iceberg, C11/C18** — backend-agnostic). Other backends are added on
+demand, not upfront.
 
 ## Open decisions
 
-| #  | Question | Proposed default |
-|----|----------|------------------|
-| D1 | Detection: reconstruction vs forecast+residual | **Reconstruction** (self-supervised) |
+| #  | Question | Decision |
+|----|----------|----------|
+| D1 | Detection mechanism | ✅ **Both, regime-switching**: forecast (anticipate the wall) in NORMAL, reconstruction (detective) at the break |
 | D2 | Mimir as sole ingress, or Kafka/OTLP in parallel for low-latency live? | TBD |
-| D3 | Plugin discovery: internal registry vs Python entry-points (third-party plugins) | Internal first |
-| D4 | Pivot schema: univariate vs native multivariate (PatchTST channel-independence) | TBD |
+| D3 | Plugin discovery: internal registry vs Python entry-points | ✅ **Internal registry** |
+| D4 | Pivot schema: univariate vs native multivariate | ✅ **Native multivariate** |
 | D5 | Datalake purpose: retraining vs analytics/compliance vs both | TBD |
 
 ## Scope note — SPI vs catalog

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,52 @@
+# Roadmap
+
+Milestones are sequential; the **Connector SPI** is the cross-cutting backbone.
+See [ARCHITECTURE.md](./ARCHITECTURE.md) and [CONNECTORS.md](./CONNECTORS.md).
+
+## Milestones
+
+| Milestone | Deliverable | Priority |
+|-----------|-------------|----------|
+| **M0** | Frozen decisions (D1–D5 below) — gate before any code beyond M2 | 🔴 blocking |
+| **M1** | PatchTST inference module decoupled from the training `Learner`: `predict(window) -> reconstruction`, RevIN normalization, checkpoint loaded once per worker | P0 |
+| **M1.5** | **Connector SPI**: pivot schema + `SourceConnector`/`SinkConnector` contracts + `registry` + contract/conformance test suite | P0 |
+| **M2** | Beam batch skeleton on DirectRunner: source → windowing → sink, no model. Validates pivot schema end-to-end (dev/test only, never prod) | P0 |
+| **M3** | PatchTST in the pipeline via `RunInference` with a custom PyTorch `ModelHandler`: per-worker load, batching, device. Output enriched with reconstruction + error | P0 |
+| **M4** | Variation detection: static thresholding first, then adaptive (rolling quantile / MAD) per `series_id`, plus anti-flapping (hysteresis, debounce) | P0 |
+| **M5** | Streaming: same pipeline unbounded — sliding windows, watermarks, late data, triggering | P1 |
+| **M6** | Production runner (Flink on-K8s or Dataflow) + pipeline monitoring (lag, throughput, failures) | P1 |
+| **M7** | KubeVerdict alerting + optional retraining loop back to the datalake | P2 |
+
+## Critical path (batch POC)
+
+```
+M0 → M1 → M1.5 → M2 → M3 → M4
+```
+
+End-to-end variation detection on historical data, without touching streaming or
+Flink. This de-risks the two fragile joints — inference-in-Beam and the model's
+real value — before investing in streaming ops.
+
+## Connector workstream
+
+Once the SPI (M1.5) is frozen, each connector is a small, parallelizable PR:
+drop a file under `connectors/sources/` or `connectors/sinks/` with
+`@connector("name")` and pass the conformance suite. P0 connectors for the POC:
+**Mimir (C9a)** source and **MinIO/Iceberg (C11/C18)** sink.
+
+## Open decisions
+
+| #  | Question | Proposed default |
+|----|----------|------------------|
+| D1 | Detection: reconstruction vs forecast+residual | **Reconstruction** (self-supervised) |
+| D2 | Mimir as sole ingress, or Kafka/OTLP in parallel for low-latency live? | TBD |
+| D3 | Plugin discovery: internal registry vs Python entry-points (third-party plugins) | Internal first |
+| D4 | Pivot schema: univariate vs native multivariate (PatchTST channel-independence) | TBD |
+| D5 | Datalake purpose: retraining vs analytics/compliance vs both | TBD |
+
+## Scope note — SPI vs catalog
+
+The real P0 deliverable is **not** "write the Mimir and MinIO connectors". It is
+freezing the **pivot contract + registry + conformance suite** (M1.5). After
+that, Mimir / Kafka / MinIO / ClickHouse are a few files each, written in
+parallel without touching the core.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,8 +44,9 @@ demand, not upfront.
 | D2 | Mimir as sole ingress, or Kafka/OTLP in parallel for low-latency live? | TBD |
 | D3 | Plugin discovery: internal registry vs Python entry-points | ✅ **Internal registry** |
 | D4 | Pivot schema: univariate vs native multivariate | ✅ **Native multivariate** |
-| D5 | Datalake purpose: retraining vs analytics/compliance vs both | TBD |
+| D5 | Datalake purpose: retraining vs analytics/compliance vs both | ✅ **Knowledge base** — longitudinal signal history kube-verdict queries as RCA evidence |
 | D6 | Engine coupling: Beam in the contract vs engine-agnostic core | ✅ **Engine-agnostic** (ports & adapters): Local + Beam engines, Spark/Databricks next |
+| D7 | How kube-verdict consumes the knowledge base | ✅ **Structured datalake first** (`kb/`: SignalRecord + DuckDB query + `signal_history` API); semantic Weaviate face next; don't re-implement its detector |
 
 ## Scope note — SPI vs catalog
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,6 +45,7 @@ demand, not upfront.
 | D3 | Plugin discovery: internal registry vs Python entry-points | ✅ **Internal registry** |
 | D4 | Pivot schema: univariate vs native multivariate | ✅ **Native multivariate** |
 | D5 | Datalake purpose: retraining vs analytics/compliance vs both | TBD |
+| D6 | Engine coupling: Beam in the contract vs engine-agnostic core | ✅ **Engine-agnostic** (ports & adapters): Local + Beam engines, Spark/Databricks next |
 
 ## Scope note — SPI vs catalog
 

--- a/inference/__init__.py
+++ b/inference/__init__.py
@@ -1,0 +1,19 @@
+"""PatchTST inference module (roadmap M1).
+
+Decouples PatchTST from the training ``Learner``: a checkpoint-backed engine that
+exposes the model's **two heads** as plain methods — ``forecast(window)`` and
+``reconstruct(window)`` — with RevIN normalization and the checkpoint loaded once
+per process (per Beam worker, later). No optimizer, no dataloader, no training.
+
+The two heads come from two checkpoints sharing the PatchTST architecture but not
+their weights: the *reconstruct* head from self-supervised masked pretraining, the
+*forecast* head from the supervised finetune (whose backbone has diverged from the
+pretrain backbone). The engine therefore holds two independent ``PatchTST``
+instances — see docs/ROADMAP.md (M1) and the D1 detection faces it feeds.
+"""
+from __future__ import annotations
+
+from .config import ModelSpec
+from .engine import ForecastResult, PatchTSTInference, ReconstructResult
+
+__all__ = ["ModelSpec", "PatchTSTInference", "ForecastResult", "ReconstructResult"]

--- a/inference/config.py
+++ b/inference/config.py
@@ -1,0 +1,50 @@
+"""Architecture spec for a PatchTST checkpoint.
+
+A checkpoint is just a ``state_dict``; to load it we must rebuild the exact module
+that produced it. ``ModelSpec`` captures the architecture hyper-parameters (the
+ones that change tensor shapes) so forecast and reconstruct checkpoints can be
+re-instantiated and loaded. Values mirror the defaults used by the training
+scripts' ``get_model`` (shared embedding, relu activation, non-residual
+attention) — keep them in sync with the checkpoint you load.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """Shape-defining hyper-parameters of a PatchTST model.
+
+    ``c_in`` is the number of channels (native-multivariate, decision D4).
+    ``context_length`` is the input window length; ``target_length`` the forecast
+    horizon (ignored by the reconstruction head). The window fed to the engine
+    must be exactly ``context_length`` long, since the prediction head's linear
+    layer is sized from ``num_patch``.
+    """
+
+    c_in: int
+    context_length: int
+    target_length: int
+    patch_len: int = 8
+    stride: int = 8
+    n_layers: int = 2
+    d_model: int = 32
+    n_heads: int = 4
+    d_ff: int = 128
+    dropout: float = 0.0
+    head_dropout: float = 0.0
+    shared_embedding: bool = True
+    res_attention: bool = False
+    activation: str = "relu"
+
+    @property
+    def num_patch(self) -> int:
+        """Number of patches produced from a ``context_length`` window."""
+        return (max(self.context_length, self.patch_len) - self.patch_len) // self.stride + 1
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ModelSpec":
+        """Build from a plain dict (e.g. parsed YAML), ignoring unknown keys."""
+        fields = cls.__dataclass_fields__  # type: ignore[attr-defined]
+        return cls(**{k: v for k, v in d.items() if k in fields})

--- a/inference/engine.py
+++ b/inference/engine.py
@@ -1,0 +1,241 @@
+"""PatchTSTInference — the M1 engine.
+
+Loads two PatchTST checkpoints once (forecast = prediction head, reconstruct =
+pretrain head) and exposes them as ``forecast(window)`` / ``reconstruct(window)``.
+RevIN instance-normalizes each window the same way training did (affine-free):
+forecast denormalizes its prediction back to the input's scale; reconstruction
+error is reported in normalized space (scale-invariant, the right unit for an
+anomaly score).
+
+Heavy deps (``torch``, the vendored ``PatchTST_self_supervised`` package) are
+imported lazily so ``import inference`` stays cheap for callers that only need the
+config. Construct the engine once per worker; ``forecast``/``reconstruct`` then
+run under ``torch.no_grad`` with no per-call model rebuild.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+
+from .config import ModelSpec
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ForecastResult:
+    """Forecast head output, denormalized to the input window's scale.
+
+    ``prediction`` has shape ``[target_length, c_in]`` (or ``[bs, target_length,
+    c_in]`` for a batched call). ``residual``/``rmse_per_channel``/``rmse`` are
+    populated only when the caller passes the realized ``future`` values.
+    """
+
+    prediction: np.ndarray
+    residual: np.ndarray | None = None
+    rmse_per_channel: np.ndarray | None = None
+    rmse: float | None = None
+
+
+@dataclass
+class ReconstructResult:
+    """Reconstruction head output and error, in normalized space.
+
+    ``reconstruction`` is the patched reconstruction ``[num_patch, c_in,
+    patch_len]`` (or batched with a leading ``bs``), the native pretrain-head
+    layout. ``error_per_channel`` is the per-channel reconstruction MSE against
+    the patched input; higher means the window is less in-distribution.
+    """
+
+    reconstruction: np.ndarray
+    error_per_channel: np.ndarray
+    error: float
+
+
+def _select_state_dict(raw: dict) -> dict:
+    """Accept either a bare state_dict or ``{'model': ..., 'opt': ...}``."""
+    if "model" in raw and isinstance(raw["model"], dict):
+        return raw["model"]
+    return raw
+
+
+class PatchTSTInference:
+    """Checkpoint-backed PatchTST inference with both heads.
+
+    Build via :meth:`from_checkpoints`. The forecast and reconstruct models are
+    independent ``PatchTST`` instances (their backbones diverged during finetune),
+    each loaded from its own checkpoint and set to ``eval()`` on ``device``.
+    """
+
+    def __init__(self, forecast_model, reconstruct_model, spec: ModelSpec, device: str):
+        self.spec = spec
+        self.device = device
+        self._forecast_model = forecast_model
+        self._reconstruct_model = reconstruct_model
+
+    # ---- construction -------------------------------------------------------
+
+    @classmethod
+    def from_checkpoints(
+        cls,
+        forecast_ckpt: str,
+        reconstruct_ckpt: str,
+        spec: ModelSpec,
+        device: str = "cpu",
+        strict: bool = True,
+        _loader: Callable | None = None,
+    ) -> "PatchTSTInference":
+        """Load both checkpoints once and return a ready engine.
+
+        ``_loader`` is an injection seam for tests (defaults to ``torch.load``);
+        production callers leave it unset.
+        """
+        import torch
+
+        load = _loader or (lambda p: torch.load(p, map_location=device))
+
+        forecast_model = cls._build(spec, head_type="prediction")
+        reconstruct_model = cls._build(spec, head_type="pretrain")
+
+        cls._load_into(forecast_model, load(forecast_ckpt), strict, "forecast")
+        cls._load_into(reconstruct_model, load(reconstruct_ckpt), strict, "reconstruct")
+
+        forecast_model.to(device).eval()
+        reconstruct_model.to(device).eval()
+        return cls(forecast_model, reconstruct_model, spec, device)
+
+    @staticmethod
+    def _build(spec: ModelSpec, head_type: str):
+        from PatchTST_self_supervised.src.models.patchTST import PatchTST
+
+        return PatchTST(
+            c_in=spec.c_in,
+            target_dim=spec.target_length,
+            patch_len=spec.patch_len,
+            stride=spec.stride,
+            num_patch=spec.num_patch,
+            n_layers=spec.n_layers,
+            d_model=spec.d_model,
+            n_heads=spec.n_heads,
+            shared_embedding=spec.shared_embedding,
+            d_ff=spec.d_ff,
+            dropout=spec.dropout,
+            head_dropout=spec.head_dropout,
+            act=spec.activation,
+            res_attention=spec.res_attention,
+            head_type=head_type,
+        )
+
+    @staticmethod
+    def _load_into(model, raw: dict, strict: bool, label: str) -> None:
+        result = model.load_state_dict(_select_state_dict(raw), strict=strict)
+        missing = getattr(result, "missing_keys", [])
+        unexpected = getattr(result, "unexpected_keys", [])
+        if missing or unexpected:
+            log.warning(
+                "%s checkpoint loaded with missing=%s unexpected=%s",
+                label, missing, unexpected,
+            )
+
+    # ---- inference ----------------------------------------------------------
+
+    def forecast(self, window: np.ndarray, future: np.ndarray | None = None) -> ForecastResult:
+        """Forecast the next ``target_length`` steps from a context window.
+
+        ``window``: ``[context_length, c_in]`` or batched ``[bs, context_length,
+        c_in]``. If ``future`` (the realized horizon, same channel layout) is
+        given, residual and RMSE are filled in.
+        """
+        import torch
+
+        x, batched = self._to_btc(window, self.spec.context_length, "window")
+        revin = self._revin()
+        with torch.no_grad():
+            xn = revin(x, "norm")
+            patched = self._patch(xn)
+            pred = self._forecast_model(patched)          # [bs, target_length, c_in]
+            pred = revin(pred, "denorm")
+        pred_np = self._out(pred, batched)
+
+        res = ForecastResult(prediction=pred_np)
+        if future is not None:
+            fut, _ = self._to_btc(future, self.spec.target_length, "future")
+            fut_np = self._out(fut, batched)
+            diff = pred_np - fut_np
+            res.residual = diff
+            axis = tuple(range(diff.ndim - 1))            # all but channel axis
+            res.rmse_per_channel = np.sqrt(np.mean(diff**2, axis=axis))
+            res.rmse = float(np.sqrt(np.mean(diff**2)))
+        return res
+
+    def reconstruct(self, window: np.ndarray) -> ReconstructResult:
+        """Reconstruct a window and report per-channel reconstruction error.
+
+        ``window``: ``[context_length, c_in]`` or batched. Error is the MSE
+        between the patched input and its reconstruction, in normalized space.
+        """
+        import torch
+
+        x, batched = self._to_btc(window, self.spec.context_length, "window")
+        revin = self._revin()
+        with torch.no_grad():
+            xn = revin(x, "norm")
+            patched = self._patch(xn)                      # [bs, num_patch, c_in, patch_len]
+            recon = self._reconstruct_model(patched)       # same shape
+            err = (recon - patched) ** 2
+
+        # mean over patches & patch_len, keep batch and channel: [bs, c_in]
+        err_pc = err.mean(dim=(1, 3)).cpu().numpy()
+        recon_np = recon.cpu().numpy()
+        if not batched:
+            recon_np = recon_np[0]
+            err_pc = err_pc[0]
+        return ReconstructResult(
+            reconstruction=recon_np,
+            error_per_channel=err_pc,
+            error=float(err_pc.mean()),
+        )
+
+    # ---- helpers ------------------------------------------------------------
+
+    def _revin(self):
+        from PatchTST_self_supervised.src.models.layers.revin import RevIN
+
+        return RevIN(self.spec.c_in, affine=False).to(self.device)
+
+    def _patch(self, xn):
+        from PatchTST_self_supervised.src.callback.patch_mask import create_patch
+
+        patched, _ = create_patch(xn, self.spec.patch_len, self.spec.stride)
+        return patched
+
+    def _to_btc(self, arr: np.ndarray, expect_len: int, name: str):
+        """Coerce to a ``[bs, length, c_in]`` float tensor; report if batched."""
+        import torch
+
+        a = np.asarray(arr, dtype=np.float32)
+        if a.ndim == 2:
+            a = a[None, ...]
+            batched = False
+        elif a.ndim == 3:
+            batched = True
+        else:
+            raise ValueError(f"{name} must be 2D [L, C] or 3D [B, L, C], got shape {a.shape}")
+
+        if a.shape[1] != expect_len:
+            raise ValueError(
+                f"{name} length {a.shape[1]} != expected {expect_len}"
+            )
+        if a.shape[2] != self.spec.c_in:
+            raise ValueError(
+                f"{name} channels {a.shape[2]} != c_in {self.spec.c_in}"
+            )
+        return torch.from_numpy(a).to(self.device), batched
+
+    @staticmethod
+    def _out(t, batched: bool) -> np.ndarray:
+        a = t.cpu().numpy()
+        return a if batched else a[0]

--- a/kb/__init__.py
+++ b/kb/__init__.py
@@ -1,0 +1,20 @@
+"""Knowledge base — aggregated signal store + query service (D7).
+
+The longitudinal evidence layer that kube-verdict queries during RCA. See
+docs/ARCHITECTURE.md. Public surface: the signal schema, the store, and the
+HTTP app factory.
+"""
+from .signal import SignalRecord
+from .store import SignalStore
+
+# Register the SPI sink façade (write path goes through the connector cycle).
+from .sink import SignalStoreSink  # noqa: E402
+
+__all__ = ["SignalRecord", "SignalStore", "SignalStoreSink", "create_app"]
+
+
+def create_app(store: SignalStore):
+    # lazy import so the schema/store are usable without FastAPI installed
+    from .api import create_app as _create_app
+
+    return _create_app(store)

--- a/kb/api.py
+++ b/kb/api.py
@@ -1,0 +1,44 @@
+"""Signal knowledge-base HTTP service.
+
+Exposes the read contract kube-verdict's ``rca/context_builder`` calls during
+RCA — "give me the signal history of this entity":
+
+    GET /api/v1/signals/history?entity=Pod/prod/api&metric=cpu_usage&since=..&until=..
+
+Returns aggregated SignalRecords as historical evidence. Read-only; the write
+path is the aggregation pipeline (connectors + engines) feeding the store.
+"""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Optional
+
+from fastapi import FastAPI, Query
+
+from .store import SignalStore
+
+
+def create_app(store: SignalStore) -> FastAPI:
+    app = FastAPI(title="Signal Knowledge Base", version="0.1.0")
+
+    @app.get("/health")
+    def health() -> dict:
+        return {"status": "ok"}
+
+    @app.get("/api/v1/signals/history")
+    def signal_history(
+        entity: str = Query(..., description="entity_uid, e.g. 'Pod/prod/api-7c9'"),
+        metric: Optional[str] = Query(None, description="filter by metric name"),
+        since: Optional[int] = Query(None, description="epoch-ms lower bound"),
+        until: Optional[int] = Query(None, description="epoch-ms upper bound"),
+        limit: Optional[int] = Query(None, ge=1, description="max records"),
+    ) -> dict:
+        records = store.query(entity, metric=metric, since=since, until=until, limit=limit)
+        return {
+            "entity": entity,
+            "metric": metric,
+            "count": len(records),
+            "signals": [asdict(r) for r in records],
+        }
+
+    return app

--- a/kb/signal.py
+++ b/kb/signal.py
@@ -1,0 +1,72 @@
+"""SignalRecord — one aggregated signal in the knowledge base.
+
+Schema deliberately aligned with kube-verdict's ``AnomalyResult`` so the
+knowledge base speaks its language: kube-verdict's RCA (``rca/context_builder``)
+queries this store by entity/metric/window as historical evidence. See
+docs/ARCHITECTURE.md (D7).
+
+This is the *aggregated output* schema, distinct from the raw-metric
+``connectors.PivotRow`` input schema.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+SEVERITIES = ("normal", "warning", "critical")
+HORIZONS = ("", "short", "medium", "long")
+
+
+@dataclass(frozen=True, slots=True)
+class SignalRecord:
+    entity_uid: str            # e.g. "Pod/prod/api-7c9"
+    metric_name: str           # e.g. "cpu_usage"
+    ts: int                    # epoch milliseconds the signal was observed
+    severity: str              # normal | warning | critical
+    score: float               # anomaly score (>= warning_threshold = anomalous)
+    method: str                # "patchtst" | "zscore"
+    horizon: str = ""          # short | medium | long | ""
+    n_points: int = 0
+    labels: dict[str, str] = field(default_factory=dict)
+    text: str = ""             # narrative; embedded later for semantic lookup
+
+    def __post_init__(self) -> None:
+        if not self.entity_uid:
+            raise ValueError("entity_uid must be non-empty")
+        if not isinstance(self.ts, int):
+            raise ValueError(f"ts must be int epoch-ms, got {type(self.ts).__name__}")
+        if self.severity not in SEVERITIES:
+            raise ValueError(f"severity must be one of {SEVERITIES}, got {self.severity!r}")
+        if self.horizon not in HORIZONS:
+            raise ValueError(f"horizon must be one of {HORIZONS}, got {self.horizon!r}")
+
+    @property
+    def is_anomalous(self) -> bool:
+        return self.severity != "normal"
+
+    def to_text(self) -> str:
+        """Narrative form (mirrors kube-verdict AnomalyResult.to_text) for the
+        semantic/vector face of the knowledge base."""
+        if self.text:
+            return self.text
+        horizon_part = f" horizon={self.horizon}" if self.horizon else ""
+        return (
+            f"signal metric={self.metric_name} entity={self.entity_uid}"
+            f"{horizon_part} severity={self.severity} score={self.score:.3f} "
+            f"method={self.method} n={self.n_points}"
+        )
+
+    @classmethod
+    def from_anomaly_result(cls, result, *, ts: int, labels=None) -> "SignalRecord":
+        """Build from a kube-verdict ``AnomalyResult`` (duck-typed)."""
+        return cls(
+            entity_uid=result.entity_uid,
+            metric_name=result.metric_name,
+            ts=ts,
+            severity=result.severity,
+            score=float(result.score),
+            method=result.method,
+            horizon=getattr(result, "horizon", "") or "",
+            n_points=int(getattr(result, "n_points", 0)),
+            labels=dict(labels or {}),
+            text=result.to_text() if hasattr(result, "to_text") else "",
+        )

--- a/kb/sink.py
+++ b/kb/sink.py
@@ -1,0 +1,40 @@
+"""SignalStore as an SPI sink — aligns the knowledge-base WRITE path with the
+connector cycle.
+
+Without this, signals could be written two ways (the SPI *and* a standalone
+``SignalStore.write``) — a divergence. This façade makes writing a signal go
+through the same cycle as every other sink:
+
+    build("signal-store", root=...) → Engine.run(source, [sink]) → sink.write(rows)
+
+Dependency direction is correct: ``kb`` (higher level) depends on the connector
+SPI, never the reverse. Registration happens when ``kb`` is imported.
+
+Note: the knowledge-base READ path (``SignalStore.query`` / the HTTP service)
+stays *outside* the SPI on purpose — it is a request/response serving concern,
+not streaming dataflow.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+from connectors.base import SinkConnector
+from connectors.registry import connector
+
+from .signal import SignalRecord
+from .store import SignalStore
+
+
+@connector("signal-store")
+class SignalStoreSink(SinkConnector):
+    """Write aggregated ``SignalRecord``s into the knowledge base via the SPI."""
+
+    def __init__(self, root: str) -> None:
+        self.root = root
+        self.store = SignalStore(root)
+
+    def write(self, rows: Iterable[SignalRecord]) -> None:
+        self.store.write(rows)
+
+    def describe(self) -> dict:
+        return {**super().describe(), "root": self.root}

--- a/kb/store.py
+++ b/kb/store.py
@@ -1,0 +1,135 @@
+"""SignalStore — the structured knowledge base.
+
+Aggregated ``SignalRecord``s are written as Parquet (the datalake) and queried
+by entity/metric/time-window via DuckDB. This is the read path kube-verdict's
+``rca/context_builder`` uses as historical evidence: "what is the signal history
+of this entity?"
+
+Parquet + DuckDB keeps the POC dependency-light and S3-ready (DuckDB reads
+``s3://`` and Iceberg too); a ClickHouse backend can replace it at scale behind
+the same ``write`` / ``query`` interface.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import uuid
+from typing import Iterable
+
+from .signal import SignalRecord
+
+_COLUMNS = [
+    "entity_uid", "metric_name", "ts", "severity",
+    "score", "method", "horizon", "n_points", "labels", "text",
+]
+
+
+class SignalStore:
+    def __init__(self, root: str) -> None:
+        self.root = root
+
+    def _schema(self):
+        import pyarrow as pa
+
+        return pa.schema(
+            [
+                ("entity_uid", pa.string()),
+                ("metric_name", pa.string()),
+                ("ts", pa.int64()),
+                ("severity", pa.string()),
+                ("score", pa.float64()),
+                ("method", pa.string()),
+                ("horizon", pa.string()),
+                ("n_points", pa.int64()),
+                ("labels", pa.string()),   # JSON
+                ("text", pa.string()),
+            ]
+        )
+
+    @staticmethod
+    def _to_dict(r: SignalRecord) -> dict:
+        return {
+            "entity_uid": r.entity_uid,
+            "metric_name": r.metric_name,
+            "ts": int(r.ts),
+            "severity": r.severity,
+            "score": float(r.score),
+            "method": r.method,
+            "horizon": r.horizon,
+            "n_points": int(r.n_points),
+            "labels": json.dumps(dict(r.labels), sort_keys=True),
+            "text": r.to_text(),
+        }
+
+    def write(self, records: Iterable[SignalRecord]) -> str | None:
+        """Append a Parquet partition of signals; return its path (or None if empty)."""
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        rows = [self._to_dict(r) for r in records]
+        if not rows:
+            return None
+        os.makedirs(self.root, exist_ok=True)
+        path = os.path.join(self.root, f"signals-{uuid.uuid4().hex}.parquet")
+        pq.write_table(pa.Table.from_pylist(rows, schema=self._schema()), path)
+        return path
+
+    def query(
+        self,
+        entity_uid: str,
+        metric: str | None = None,
+        since: int | None = None,
+        until: int | None = None,
+        limit: int | None = None,
+    ) -> list[SignalRecord]:
+        """Signal history for an entity, optionally filtered by metric/time window.
+
+        This is the contract kube-verdict's context_builder calls.
+        """
+        import duckdb
+
+        files = sorted(glob.glob(os.path.join(self.root, "*.parquet")))
+        if not files:
+            return []
+
+        conds = ["entity_uid = ?"]
+        params: list = [entity_uid]
+        if metric is not None:
+            conds.append("metric_name = ?")
+            params.append(metric)
+        if since is not None:
+            conds.append("ts >= ?")
+            params.append(int(since))
+        if until is not None:
+            conds.append("ts <= ?")
+            params.append(int(until))
+
+        sql = (
+            f"SELECT {', '.join(_COLUMNS)} FROM read_parquet(?) "
+            f"WHERE {' AND '.join(conds)} ORDER BY ts"
+        )
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+
+        con = duckdb.connect()
+        try:
+            rows = con.execute(sql, [files, *params]).fetchall()
+        finally:
+            con.close()
+
+        return [
+            SignalRecord(
+                entity_uid=r[0],
+                metric_name=r[1],
+                ts=int(r[2]),
+                severity=r[3],
+                score=float(r[4]),
+                method=r[5],
+                horizon=r[6] or "",
+                n_points=int(r[7]),
+                labels=json.loads(r[8] or "{}"),
+                text=r[9] or "",
+            )
+            for r in rows
+        ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,6 @@ addopts =
     --cov=connectors
     --cov=kb
     --cov=detection
+    --cov=inference
     --cov-report=term-missing
     --cov-fail-under=75

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,6 @@
 testpaths = tests
 addopts =
     --cov=connectors
+    --cov=kb
     --cov-report=term-missing
     --cov-fail-under=75

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,5 +3,6 @@ testpaths = tests
 addopts =
     --cov=connectors
     --cov=kb
+    --cov=detection
     --cov-report=term-missing
     --cov-fail-under=75

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+testpaths = tests
+addopts =
+    --cov=connectors
+    --cov-report=term-missing
+    --cov-fail-under=75

--- a/requirements-connectors.txt
+++ b/requirements-connectors.txt
@@ -1,0 +1,10 @@
+# Connector / pipeline runtime deps — kept separate from the research training
+# deps so that running PatchTST training does not require a heavy Beam install.
+#
+#   pip install -r requirements-connectors.txt
+#
+# The SPI core (pivot, registry, alignment, conformance) needs none of these;
+# they are required only to run Beam pipelines and write Parquet.
+apache-beam>=2.70
+pyarrow>=14.0
+# s3fs>=2024.2    # enable for MinIO/S3 (s3://) Parquet output

--- a/requirements-detection-patchtst.txt
+++ b/requirements-detection-patchtst.txt
@@ -1,0 +1,10 @@
+# PatchTST detector deps (optional — only needed for PatchTSTDetector).
+#
+#   pip install -r requirements-detection-patchtst.txt
+#
+# The pipeline and the ZScoreDetector need none of these; torch/transformers are
+# imported lazily inside PatchTSTDetector.detect so the package imports without
+# them. Training on the fly is compute-heavy — fit for periodic/scoped scoring.
+torch>=2.0
+transformers>=4.37
+numpy>=1.23

--- a/requirements-inference.txt
+++ b/requirements-inference.txt
@@ -1,0 +1,10 @@
+# PatchTST inference module deps (M1 — inference/).
+#
+#   pip install -r requirements-inference.txt
+#
+# Unlike the on-the-fly PatchTSTDetector (which pulls transformers), the M1 engine
+# runs the vendored PatchTST_self_supervised model directly: torch + numpy only.
+# Imports are lazy, so `import inference` works without these until you actually
+# load a checkpoint or run forecast/reconstruct.
+torch>=2.0
+numpy>=1.23

--- a/requirements-kb.txt
+++ b/requirements-kb.txt
@@ -1,0 +1,11 @@
+# Knowledge-base (signal store + query service) runtime deps.
+#
+#   pip install -r requirements-kb.txt
+#
+# Parquet datalake (write) + DuckDB (query) + FastAPI service exposing the
+# signal_history contract that kube-verdict's RCA queries.
+pyarrow>=14.0
+duckdb>=1.0
+fastapi>=0.110
+uvicorn>=0.29
+# httpx is required by fastapi.testclient for the test suite.

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -1,0 +1,302 @@
+"""Connector SPI tests — pure-Python, no Beam install required.
+
+Covers: pivot validation, internal registry, the conformance contract for the
+built-in connectors, and the multivariate alignment that backs decision D4.
+"""
+import pytest
+
+import connectors  # noqa: F401  (triggers built-in registration)
+from connectors.alignment import align_group
+from connectors.base import SinkConnector, SourceConnector
+from connectors.conformance import (
+    assert_buildable,
+    assert_registered,
+    assert_sink_contract,
+    assert_source_contract,
+)
+from connectors.pivot import PivotRow
+from connectors.registry import available, connector
+from connectors.sinks.parquet import ParquetSink
+from connectors.sources.mimir import MimirSource, query_range, to_pivot_rows
+
+
+class _FakeResp:
+    """Minimal urlopen() return value: a context manager exposing read()."""
+
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def read(self) -> bytes:
+        return self._data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# --- pivot schema ---------------------------------------------------------
+
+def test_pivot_valid():
+    row = PivotRow("pod-a", 1000, (1.0, 2.0), ("cpu", "mem"))
+    assert row.width == 2
+
+
+def test_pivot_length_mismatch():
+    with pytest.raises(ValueError, match="length mismatch"):
+        PivotRow("pod-a", 1000, (1.0,), ("cpu", "mem"))
+
+
+def test_pivot_rejects_float_ts():
+    with pytest.raises(ValueError, match="ts must be int"):
+        PivotRow("pod-a", 1000.0, (1.0,), ("cpu",))  # type: ignore[arg-type]
+
+
+def test_pivot_rejects_duplicate_channels():
+    with pytest.raises(ValueError, match="duplicate channels"):
+        PivotRow("pod-a", 1000, (1.0, 2.0), ("cpu", "cpu"))
+
+
+# --- registry -------------------------------------------------------------
+
+def test_builtins_registered():
+    reg = available()
+    assert reg.get("mimir") == "source"
+    assert reg.get("parquet") == "sink"
+
+
+def test_build_unknown_raises():
+    with pytest.raises(KeyError, match="unknown connector"):
+        assert_buildable("does-not-exist")
+
+
+# --- conformance ----------------------------------------------------------
+
+def test_mimir_conforms_to_source_contract():
+    assert_registered("mimir")
+    src = assert_buildable(
+        "mimir", endpoint="http://mimir:9009", promql="up", start=0, end=10
+    )
+    assert_source_contract(src)
+
+
+def test_parquet_conforms_to_sink_contract():
+    assert_registered("parquet")
+    sink = assert_buildable("parquet", path="/tmp/out")
+    assert_sink_contract(sink)
+
+
+# --- multivariate alignment (D4) -----------------------------------------
+
+def test_align_group_ffill_across_cadences():
+    # cpu @ 15s, mem @ 30s on a 15s grid -> mem forward-filled into the gap.
+    rows = align_group(
+        "pod-a",
+        {
+            "cpu": [(0, 1.0), (15_000, 1.1), (30_000, 1.2)],
+            "mem": [(0, 5.0), (30_000, 5.5)],
+        },
+        step_ms=15_000,
+        fill="ffill",
+    )
+    assert [r.ts for r in rows] == [0, 15_000, 30_000]
+    assert rows[0].channels == ("cpu", "mem")
+    assert rows[1].values == (1.1, 5.0)   # mem carried forward
+    assert rows[2].values == (1.2, 5.5)
+
+
+def test_align_group_drop_incomplete():
+    rows = align_group(
+        "pod-a",
+        {"cpu": [(0, 1.0), (15_000, 1.1)], "mem": [(15_000, 5.0)]},
+        step_ms=15_000,
+        fill="drop",
+    )
+    # grid bucket 0 has no mem -> dropped; only bucket 15000 is complete.
+    assert [r.ts for r in rows] == [15_000]
+
+
+def test_mimir_to_pivot_rows_groups_and_aligns():
+    result = [
+        {
+            "metric": {"__name__": "cpu", "instance": "pod-a"},
+            "values": [[0, "1.0"], [15, "1.1"]],
+        },
+        {
+            "metric": {"__name__": "mem", "instance": "pod-a"},
+            "values": [[0, "5.0"], [15, "5.5"]],
+        },
+    ]
+    rows = to_pivot_rows(
+        result,
+        group_by=["instance"],
+        channel_label="__name__",
+        step_ms=15_000,
+        fill="ffill",
+    )
+    assert {r.group_id for r in rows} == {"pod-a"}
+    assert rows[0].channels == ("cpu", "mem")
+    assert rows[0].values == (1.0, 5.0)
+
+
+# --- pivot edge cases -----------------------------------------------------
+
+def test_pivot_rejects_empty_group_id():
+    with pytest.raises(ValueError, match="group_id must be non-empty"):
+        PivotRow("", 0, (1.0,), ("cpu",))
+
+
+def test_pivot_default_labels_empty():
+    row = PivotRow("g", 0, (1.0,), ("cpu",))
+    assert row.labels == {}
+
+
+# --- registry edge cases --------------------------------------------------
+
+def test_connector_rejects_non_connector_class():
+    with pytest.raises(TypeError, match="must subclass"):
+
+        @connector("bad")
+        class _Bad:  # not a Source/Sink
+            pass
+
+
+def test_connector_rejects_duplicate_name():
+    with pytest.raises(ValueError, match="already registered"):
+
+        @connector("mimir")  # already taken by MimirSource
+        class _Dup(SourceConnector):
+            def read(self):  # pragma: no cover
+                ...
+
+
+def test_available_is_sorted():
+    keys = list(available())
+    assert keys == sorted(keys)
+
+
+def test_assert_registered_missing_raises():
+    with pytest.raises(AssertionError, match="not registered"):
+        assert_registered("nope")
+
+
+# --- alignment edge cases -------------------------------------------------
+
+def test_align_group_empty_series():
+    assert align_group("g", {}, step_ms=1000) == []
+
+
+def test_align_group_zero_fill_before_first_value():
+    # channel 'b' has no value at bucket 0 -> 'zero' fills 0.0 instead of skipping
+    rows = align_group(
+        "g",
+        {"a": [(0, 1.0)], "b": [(1000, 2.0)]},
+        step_ms=1000,
+        fill="zero",
+    )
+    assert rows[0].ts == 0 and rows[0].values == (1.0, 0.0)
+    assert rows[1].values == (1.0, 2.0)  # 'a' carried forward, 'b' now present
+
+
+def test_align_group_ffill_skips_until_all_channels_seen():
+    # 'b' only appears at bucket 2000 -> earlier buckets have no prior to ffill,
+    # so they are skipped until every channel has been seen at least once.
+    rows = align_group(
+        "g",
+        {"a": [(0, 1.0), (1000, 1.1), (2000, 1.2)], "b": [(2000, 9.0)]},
+        step_ms=1000,
+        fill="ffill",
+    )
+    assert [r.ts for r in rows] == [2000]
+    assert rows[0].values == (1.2, 9.0)
+
+
+def test_align_group_single_channel():
+    rows = align_group("g", {"cpu": [(0, 1.0), (1000, 2.0)]}, step_ms=1000)
+    assert [r.values for r in rows] == [(1.0,), (2.0,)]
+    assert all(r.width == 1 for r in rows)
+
+
+# --- connector describe / parquet record ----------------------------------
+
+def test_mimir_describe():
+    src = MimirSource("http://m:9009", "up", 0, 10, group_by=["pod"])
+    d = src.describe()
+    assert d["kind"] == "source" and d["promql"] == "up" and d["group_by"] == ["pod"]
+
+
+def test_mimir_defaults_group_id_when_label_absent():
+    result = [{"metric": {"__name__": "cpu"}, "values": [[0, "1.0"]]}]
+    rows = to_pivot_rows(
+        result, group_by=["instance"], channel_label="__name__",
+        step_ms=1000, fill="ffill",
+    )
+    assert rows[0].group_id == "default"
+
+
+def test_parquet_as_record_and_describe():
+    sink = ParquetSink("/tmp/out")
+    rec = ParquetSink.as_record(PivotRow("g", 5, (1.0, 2.0), ("a", "b"), {"k": "v"}))
+    assert rec["group_id"] == "g" and rec["values"] == [1.0, 2.0]
+    assert rec["labels"] == '{"k": "v"}'
+    assert sink.describe()["path"] == "/tmp/out"
+
+
+def test_sink_and_source_kinds():
+    assert ParquetSink("/x").kind == "sink"
+    assert MimirSource("http://m", "up", 0, 1).kind == "source"
+    assert issubclass(MimirSource, SourceConnector)
+    assert issubclass(ParquetSink, SinkConnector)
+
+
+# --- mimir HTTP query (urlopen mocked) ------------------------------------
+
+def test_query_range_success(monkeypatch):
+    import json as _json
+
+    payload = {
+        "status": "success",
+        "data": {"result": [{"metric": {}, "values": [[0, "1.0"]]}]},
+    }
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["header_values"] = list(req.headers.values())
+        return _FakeResp(_json.dumps(payload).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    out = query_range("http://mimir:9009/", "up", 0, 30, 15, tenant="team-a")
+
+    assert out == payload["data"]["result"]
+    assert "query=up" in captured["url"]
+    assert "/prometheus/api/v1/query_range" in captured["url"]
+    assert "team-a" in captured["header_values"]  # tenant header set
+
+
+def test_query_range_no_tenant_omits_header(monkeypatch):
+    import json as _json
+
+    payload = {"status": "success", "data": {"result": []}}
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["header_values"] = list(req.headers.values())
+        return _FakeResp(_json.dumps(payload).encode())
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    assert query_range("http://m", "up", 0, 1, 15) == []
+    assert captured["header_values"] == []
+
+
+def test_query_range_error_status_raises(monkeypatch):
+    import json as _json
+
+    payload = {"status": "error", "error": "bad query"}
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        lambda req, timeout=None: _FakeResp(_json.dumps(payload).encode()),
+    )
+    with pytest.raises(RuntimeError, match="bad query"):
+        query_range("http://m", "up", 0, 1, 15)

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,102 @@
+"""Detection tests — real ZScoreDetector + the PivotRow→SignalRecord transform,
+and the full write path Mimir → detection → signal-store → query."""
+import pytest
+
+import kb  # noqa: F401  (registers signal-store sink)
+from connectors import LocalEngine, build
+from connectors.pivot import PivotRow
+from detection import ZScoreDetector, detect_signals, make_detection_transform
+
+STABLE_THEN_SPIKE = [10.0] * 50 + [200.0]   # clear anomaly in the tail (z ~ 7)
+
+
+# --- ZScoreDetector (real detection) --------------------------------------
+
+def test_detector_flags_anomaly_critical():
+    r = ZScoreDetector().detect("Pod/p/a", "cpu", STABLE_THEN_SPIKE, ts=1000)
+    assert r.severity == "critical" and r.score > 4.5
+    assert r.method == "zscore" and r.n_points == 51
+
+
+def test_detector_warning_band_via_thresholds():
+    # same spike, thresholds bracket the score into the warning band
+    r = ZScoreDetector(warning=2.0, critical=100.0).detect("e", "cpu", STABLE_THEN_SPIKE, ts=0)
+    assert r.severity == "warning"
+
+
+def test_detector_constant_series_is_normal():
+    r = ZScoreDetector().detect("e", "cpu", [5.0] * 20, ts=0)
+    assert r.severity == "normal" and r.score == 0.0
+
+
+def test_detector_short_series_is_normal():
+    r = ZScoreDetector(min_points=8).detect("e", "cpu", [1.0, 99.0], ts=0)
+    assert r.severity == "normal" and r.score == 0.0 and r.n_points == 2
+
+
+# --- transform: PivotRows -> SignalRecords --------------------------------
+
+def test_detect_signals_one_per_entity_metric():
+    rows = [
+        PivotRow("e1", 1000, (1.0, 10.0), ("cpu", "mem")),
+        PivotRow("e1", 2000, (1.1, 11.0), ("cpu", "mem")),
+        PivotRow("e2", 1000, (5.0,), ("cpu",)),
+    ]
+    out = list(detect_signals(rows, ZScoreDetector(), now_ms=999))
+    keys = {(s.entity_uid, s.metric_name) for s in out}
+    assert keys == {("e1", "cpu"), ("e1", "mem"), ("e2", "cpu")}
+    assert all(s.ts == 999 for s in out)
+
+
+def test_detect_signals_default_now_ms_is_set():
+    rows = [PivotRow("e", 1, (1.0,), ("cpu",))]
+    (sig,) = list(detect_signals(rows, ZScoreDetector()))
+    assert sig.ts > 0
+
+
+# --- full write path: Mimir → detection → signal-store → query ------------
+
+def _mimir_result(values):
+    return [
+        {
+            "metric": {"__name__": "cpu", "instance": "pod-a"},
+            "values": [[i * 15, str(v)] for i, v in enumerate(values)],
+        }
+    ]
+
+
+def test_write_path_local_engine_produces_real_signal(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "connectors.sources.mimir.query_range",
+        lambda *a, **k: _mimir_result(STABLE_THEN_SPIKE),
+    )
+    source = build("mimir", endpoint="http://m", promql="cpu", start=0, end=999, step_s=15)
+    sink = build("signal-store", root=str(tmp_path / "kb"))
+    transform = make_detection_transform(ZScoreDetector(), now_ms=1700000000000)
+
+    LocalEngine().run(source, [sink], transform=transform)
+
+    signals = sink.store.query("pod-a")
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.entity_uid == "pod-a" and sig.metric_name == "cpu"
+    assert sig.severity == "critical" and sig.is_anomalous
+    assert sig.ts == 1700000000000
+
+
+def test_write_path_beam_engine_with_transform(monkeypatch, tmp_path):
+    pytest.importorskip("apache_beam")
+    from connectors.engines.beam import BeamEngine
+
+    monkeypatch.setattr(
+        "connectors.sources.mimir.query_range",
+        lambda *a, **k: _mimir_result(STABLE_THEN_SPIKE),
+    )
+    source = build("mimir", endpoint="http://m", promql="cpu", start=0, end=999, step_s=15)
+    sink = build("signal-store", root=str(tmp_path / "kb"))
+    transform = make_detection_transform(ZScoreDetector(), now_ms=1700000000000)
+
+    BeamEngine().run(source, [sink], transform=transform)
+
+    signals = sink.store.query("pod-a")
+    assert len(signals) == 1 and signals[0].severity == "critical"

--- a/tests/test_engines_local.py
+++ b/tests/test_engines_local.py
@@ -1,0 +1,78 @@
+"""LocalEngine tests — pure Python, no execution engine installed.
+
+Demonstrates the engine-agnostic core: the same connectors run with zero
+third-party engine dependency. Parquet read-back uses pyarrow (the sink's own
+dep), not Beam.
+"""
+import pyarrow.parquet as pq
+
+from connectors import LocalEngine, build
+from connectors.base import SinkConnector
+from connectors.pivot import PivotRow
+from connectors.sources.mimir import to_pivot_rows
+
+_FAKE_RESULT = [
+    {"metric": {"__name__": "cpu", "instance": "pod-a"}, "values": [[0, "1.0"], [15, "1.1"]]},
+    {"metric": {"__name__": "mem", "instance": "pod-a"}, "values": [[0, "5.0"], [15, "5.5"]]},
+]
+
+
+class _MemSink(SinkConnector):
+    """Zero-dependency sink that collects rows in memory."""
+
+    def __init__(self):
+        self.rows = []
+
+    def write(self, rows):
+        self.rows.extend(rows)
+
+
+class _StaticSource:
+    """Minimal in-memory source (duck-typed) for a dependency-free test."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def read(self):
+        return self._rows
+
+    def native_beam_read(self):
+        return None
+
+
+def test_local_engine_no_third_party_dep():
+    rows = [PivotRow("g", 0, (1.0,), ("cpu",)), PivotRow("g", 1000, (2.0,), ("cpu",))]
+    sink = _MemSink()
+    LocalEngine().run(_StaticSource(rows), [sink])
+    assert sink.rows == rows
+
+
+def test_local_engine_fans_out_to_multiple_sinks():
+    rows = [PivotRow("g", 0, (1.0,), ("cpu",))]
+    a, b = _MemSink(), _MemSink()
+    LocalEngine().run(_StaticSource(rows), [a, b])
+    assert a.rows == rows and b.rows == rows
+
+
+def test_local_engine_mimir_to_parquet(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "connectors.sources.mimir.query_range", lambda *a, **k: _FAKE_RESULT
+    )
+    src = build("mimir", endpoint="http://m", promql="up", start=0, end=30, step_s=15)
+    sink = build("parquet", path=str(tmp_path / "out"))
+
+    LocalEngine().run(src, [sink])
+
+    # agnostic writer produces a single file at path + suffix
+    table = pq.read_table(str(tmp_path / "out.parquet")).to_pydict()
+    assert table["group_id"] == ["pod-a", "pod-a"]
+    assert table["values"] == [[1.0, 5.0], [1.1, 5.5]]
+
+
+def test_mimir_read_is_engine_agnostic_iterable():
+    # read() returns plain PivotRows, no engine types
+    rows = to_pivot_rows(
+        _FAKE_RESULT, group_by=["instance"], channel_label="__name__",
+        step_ms=15_000, fill="ffill",
+    )
+    assert all(isinstance(r, PivotRow) for r in rows)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,175 @@
+"""PatchTSTInference (M1) tests.
+
+Validates the inference engine against *synthetic* checkpoints — random-weight
+PatchTST models saved to disk and reloaded — so the module is fully exercised
+without training, data, or a GPU. Covers: checkpoint round-trip, both heads'
+output shapes (single & batched), forecast residual/RMSE, RevIN invariance,
+load-once behavior, and input validation.
+"""
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from inference import ModelSpec, PatchTSTInference
+from inference.engine import _select_state_dict
+from PatchTST_self_supervised.src.models.patchTST import PatchTST
+
+
+def _spec() -> ModelSpec:
+    return ModelSpec(
+        c_in=3, context_length=16, target_length=4, patch_len=4, stride=4,
+        n_layers=1, d_model=8, n_heads=2, d_ff=16,
+    )
+
+
+def _build(spec: ModelSpec, head_type: str) -> PatchTST:
+    return PatchTST(
+        c_in=spec.c_in, target_dim=spec.target_length, patch_len=spec.patch_len,
+        stride=spec.stride, num_patch=spec.num_patch, n_layers=spec.n_layers,
+        d_model=spec.d_model, n_heads=spec.n_heads, d_ff=spec.d_ff,
+        shared_embedding=True, act="relu", res_attention=False, head_type=head_type,
+    )
+
+
+@pytest.fixture
+def engine(tmp_path):
+    spec = _spec()
+    fc, rc = _build(spec, "prediction"), _build(spec, "pretrain")
+    fp, rp = tmp_path / "fc.pth", tmp_path / "rc.pth"
+    torch.save(fc.state_dict(), fp)
+    torch.save({"model": rc.state_dict()}, rp)  # the {'model': ...} variant
+    return PatchTSTInference.from_checkpoints(str(fp), str(rp), spec)
+
+
+# ---- spec ------------------------------------------------------------------
+
+def test_num_patch():
+    assert _spec().num_patch == 4  # (16-4)//4 + 1
+
+
+def test_from_dict_ignores_unknown_keys():
+    spec = ModelSpec.from_dict(
+        {"c_in": 2, "context_length": 8, "target_length": 2, "bogus": 99}
+    )
+    assert spec.c_in == 2 and spec.context_length == 8
+
+
+# ---- checkpoint loading ----------------------------------------------------
+
+def test_select_state_dict_handles_both_shapes():
+    raw = {"a": 1}
+    assert _select_state_dict(raw) is raw
+    assert _select_state_dict({"model": raw, "opt": {}}) is raw
+
+
+def test_non_strict_load_warns_on_missing_keys(tmp_path, caplog):
+    spec = _spec()
+    fc, rc = _build(spec, "prediction"), _build(spec, "pretrain")
+    fp, rp = tmp_path / "fc.pth", tmp_path / "rc.pth"
+    partial = fc.state_dict()
+    partial.pop(next(iter(partial)))  # drop a key -> missing on load
+    torch.save(partial, fp)
+    torch.save(rc.state_dict(), rp)
+
+    with caplog.at_level("WARNING"):
+        PatchTSTInference.from_checkpoints(str(fp), str(rp), spec, strict=False)
+    assert any("missing" in r.message for r in caplog.records)
+
+
+def test_loads_once_and_does_not_reload_on_inference(tmp_path):
+    spec = _spec()
+    fc, rc = _build(spec, "prediction"), _build(spec, "pretrain")
+    fp, rp = tmp_path / "fc.pth", tmp_path / "rc.pth"
+    torch.save(fc.state_dict(), fp)
+    torch.save(rc.state_dict(), rp)
+
+    calls = {"n": 0}
+
+    def counting_loader(path):
+        calls["n"] += 1
+        return torch.load(path, map_location="cpu")
+
+    eng = PatchTSTInference.from_checkpoints(
+        str(fp), str(rp), spec, _loader=counting_loader
+    )
+    assert calls["n"] == 2  # one load per checkpoint, at construction
+
+    w = np.random.randn(16, 3).astype("float32")
+    eng.forecast(w)
+    eng.reconstruct(w)
+    assert calls["n"] == 2  # inference must not reload the model
+
+
+# ---- forecast --------------------------------------------------------------
+
+def test_forecast_shape_single(engine):
+    out = engine.forecast(np.random.randn(16, 3).astype("float32"))
+    assert out.prediction.shape == (4, 3)
+    assert out.residual is None and out.rmse is None
+
+
+def test_forecast_shape_batched(engine):
+    out = engine.forecast(np.random.randn(5, 16, 3).astype("float32"))
+    assert out.prediction.shape == (5, 4, 3)
+
+
+def test_forecast_with_future_fills_residual(engine):
+    w = np.random.randn(16, 3).astype("float32")
+    fut = np.random.randn(4, 3).astype("float32")
+    out = engine.forecast(w, future=fut)
+    assert out.residual.shape == (4, 3)
+    assert out.rmse_per_channel.shape == (3,)
+    assert out.rmse == pytest.approx(
+        float(np.sqrt(np.mean(out.residual**2))), rel=1e-5
+    )
+
+
+def test_forecast_deterministic_in_eval(engine):
+    w = np.random.randn(16, 3).astype("float32")
+    a = engine.forecast(w).prediction
+    b = engine.forecast(w).prediction
+    np.testing.assert_allclose(a, b)  # eval() => dropout off => repeatable
+
+
+# ---- reconstruct -----------------------------------------------------------
+
+def test_reconstruct_shape_single(engine):
+    out = engine.reconstruct(np.random.randn(16, 3).astype("float32"))
+    assert out.reconstruction.shape == (4, 3, 4)  # [num_patch, c_in, patch_len]
+    assert out.error_per_channel.shape == (3,)
+    assert out.error >= 0.0
+
+
+def test_reconstruct_shape_batched(engine):
+    out = engine.reconstruct(np.random.randn(2, 16, 3).astype("float32"))
+    assert out.reconstruction.shape == (2, 4, 3, 4)
+    assert out.error_per_channel.shape == (2, 3)
+
+
+# ---- RevIN -----------------------------------------------------------------
+
+def test_revin_roundtrip_invariance(engine):
+    from PatchTST_self_supervised.src.models.layers.revin import RevIN
+
+    r = RevIN(3, affine=False)
+    x = torch.randn(2, 16, 3)
+    back = r(r(x, "norm"), "denorm")
+    assert torch.max(torch.abs(x - back)).item() < 1e-4
+
+
+# ---- validation ------------------------------------------------------------
+
+def test_wrong_window_length_raises(engine):
+    with pytest.raises(ValueError, match="length"):
+        engine.forecast(np.random.randn(10, 3).astype("float32"))
+
+
+def test_wrong_channel_count_raises(engine):
+    with pytest.raises(ValueError, match="channels"):
+        engine.forecast(np.random.randn(16, 5).astype("float32"))
+
+
+def test_bad_ndim_raises(engine):
+    with pytest.raises(ValueError, match="2D|3D"):
+        engine.forecast(np.random.randn(16).astype("float32"))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,87 @@
+"""Integration tests — real Beam pipelines on the DirectRunner.
+
+Exercises the beam-dependent connector paths (``MimirSource.read`` and
+``ParquetSink.write``) end-to-end, including a source -> sink round trip.
+Network is mocked; no external services required.
+
+Skipped automatically if apache-beam / pyarrow are not installed.
+"""
+import glob
+import json
+
+import pytest
+
+beam = pytest.importorskip("apache_beam")
+pq = pytest.importorskip("pyarrow.parquet")
+# aliased to avoid pytest trying to collect it as a test class
+from apache_beam.testing.test_pipeline import TestPipeline as Pipeline  # noqa: E402
+from apache_beam.testing.util import assert_that, equal_to  # noqa: E402
+
+from connectors import build  # noqa: E402
+from connectors.pivot import PivotRow  # noqa: E402
+
+_FAKE_RESULT = [
+    {
+        "metric": {"__name__": "cpu", "instance": "pod-a"},
+        "values": [[0, "1.0"], [15, "1.1"]],
+    },
+    {
+        "metric": {"__name__": "mem", "instance": "pod-a"},
+        "values": [[0, "5.0"], [15, "5.5"]],
+    },
+]
+
+
+@pytest.fixture
+def mimir_source(monkeypatch):
+    monkeypatch.setattr(
+        "connectors.sources.mimir.query_range", lambda *a, **k: _FAKE_RESULT
+    )
+    return build(
+        "mimir",
+        endpoint="http://mimir:9009",
+        promql="up",
+        start=0,
+        end=30,
+        step_s=15,
+    )
+
+
+def test_mimir_source_read_pipeline(mimir_source):
+    expected = [
+        PivotRow("pod-a", 0, (1.0, 5.0), ("cpu", "mem"), {"instance": "pod-a"}),
+        PivotRow("pod-a", 15_000, (1.1, 5.5), ("cpu", "mem"), {"instance": "pod-a"}),
+    ]
+    with Pipeline() as p:
+        out = p | mimir_source.read()
+        assert_that(out, equal_to(expected))
+
+
+def test_parquet_sink_roundtrip(tmp_path):
+    sink = build("parquet", path=str(tmp_path / "out"), num_shards=1)
+    rows = [
+        PivotRow("pod-a", 0, (1.0, 5.0), ("cpu", "mem"), {"k": "v"}),
+        PivotRow("pod-a", 15_000, (1.1, 5.5), ("cpu", "mem"), {"k": "v"}),
+    ]
+    with Pipeline() as p:
+        p | beam.Create(rows) | sink.write()
+
+    files = sorted(glob.glob(str(tmp_path / "out*")))
+    assert files, "no parquet output written"
+    table = pq.read_table(files[0]).to_pydict()
+    assert table["group_id"] == ["pod-a", "pod-a"]
+    assert table["values"] == [[1.0, 5.0], [1.1, 5.5]]
+    assert json.loads(table["labels"][0]) == {"k": "v"}
+
+
+def test_mimir_to_parquet_e2e(mimir_source, tmp_path):
+    sink = build("parquet", path=str(tmp_path / "e2e"), num_shards=1)
+    with Pipeline() as p:
+        p | mimir_source.read() | sink.write()
+
+    files = sorted(glob.glob(str(tmp_path / "e2e*")))
+    assert files, "no parquet output written"
+    table = pq.read_table(files[0]).to_pydict()
+    assert len(table["group_id"]) == 2
+    assert table["channels"][0] == ["cpu", "mem"]
+    assert sorted(table["values"]) == [[1.0, 5.0], [1.1, 5.5]]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,35 +1,39 @@
-"""Integration tests — real Beam pipelines on the DirectRunner.
+"""Integration tests — the Beam engine adapter on the DirectRunner.
 
-Exercises the beam-dependent connector paths (``MimirSource.read`` and
-``ParquetSink.write``) end-to-end, including a source -> sink round trip.
-Network is mocked; no external services required.
-
-Skipped automatically if apache-beam / pyarrow are not installed.
+Exercises BeamEngine end-to-end (read wrap + native Parquet writer + the
+gather-and-call fallback for a sink without a native hook). Network is mocked;
+no external services required. Skipped if apache-beam / pyarrow are absent.
 """
 import glob
-import json
 
 import pytest
 
 beam = pytest.importorskip("apache_beam")
 pq = pytest.importorskip("pyarrow.parquet")
-# aliased to avoid pytest trying to collect it as a test class
-from apache_beam.testing.test_pipeline import TestPipeline as Pipeline  # noqa: E402
-from apache_beam.testing.util import assert_that, equal_to  # noqa: E402
 
 from connectors import build  # noqa: E402
-from connectors.pivot import PivotRow  # noqa: E402
+from connectors.base import SinkConnector  # noqa: E402
+from connectors.engines.beam import BeamEngine  # noqa: E402
 
 _FAKE_RESULT = [
-    {
-        "metric": {"__name__": "cpu", "instance": "pod-a"},
-        "values": [[0, "1.0"], [15, "1.1"]],
-    },
-    {
-        "metric": {"__name__": "mem", "instance": "pod-a"},
-        "values": [[0, "5.0"], [15, "5.5"]],
-    },
+    {"metric": {"__name__": "cpu", "instance": "pod-a"}, "values": [[0, "1.0"], [15, "1.1"]]},
+    {"metric": {"__name__": "mem", "instance": "pod-a"}, "values": [[0, "5.0"], [15, "5.5"]]},
 ]
+
+
+class _FileSink(SinkConnector):
+    """Sink with NO native hook — exercises the Beam fallback path.
+
+    Module-level (picklable) so DirectRunner can serialize it.
+    """
+
+    def __init__(self, path):
+        self.path = path
+
+    def write(self, rows):
+        with open(self.path, "w") as f:
+            for r in rows:
+                f.write(f"{r.group_id}\n")
 
 
 @pytest.fixture
@@ -38,50 +42,27 @@ def mimir_source(monkeypatch):
         "connectors.sources.mimir.query_range", lambda *a, **k: _FAKE_RESULT
     )
     return build(
-        "mimir",
-        endpoint="http://mimir:9009",
-        promql="up",
-        start=0,
-        end=30,
-        step_s=15,
+        "mimir", endpoint="http://mimir:9009", promql="up", start=0, end=30, step_s=15
     )
 
 
-def test_mimir_source_read_pipeline(mimir_source):
-    expected = [
-        PivotRow("pod-a", 0, (1.0, 5.0), ("cpu", "mem"), {"instance": "pod-a"}),
-        PivotRow("pod-a", 15_000, (1.1, 5.5), ("cpu", "mem"), {"instance": "pod-a"}),
-    ]
-    with Pipeline() as p:
-        out = p | mimir_source.read()
-        assert_that(out, equal_to(expected))
-
-
-def test_parquet_sink_roundtrip(tmp_path):
-    sink = build("parquet", path=str(tmp_path / "out"), num_shards=1)
-    rows = [
-        PivotRow("pod-a", 0, (1.0, 5.0), ("cpu", "mem"), {"k": "v"}),
-        PivotRow("pod-a", 15_000, (1.1, 5.5), ("cpu", "mem"), {"k": "v"}),
-    ]
-    with Pipeline() as p:
-        p | beam.Create(rows) | sink.write()
-
-    files = sorted(glob.glob(str(tmp_path / "out*")))
-    assert files, "no parquet output written"
-    table = pq.read_table(files[0]).to_pydict()
-    assert table["group_id"] == ["pod-a", "pod-a"]
-    assert table["values"] == [[1.0, 5.0], [1.1, 5.5]]
-    assert json.loads(table["labels"][0]) == {"k": "v"}
-
-
-def test_mimir_to_parquet_e2e(mimir_source, tmp_path):
+def test_beam_engine_mimir_to_parquet_native(mimir_source, tmp_path):
+    # ParquetSink provides native_beam_write -> distributed WriteToParquet
     sink = build("parquet", path=str(tmp_path / "e2e"), num_shards=1)
-    with Pipeline() as p:
-        p | mimir_source.read() | sink.write()
+    BeamEngine().run(mimir_source, [sink])
 
     files = sorted(glob.glob(str(tmp_path / "e2e*")))
-    assert files, "no parquet output written"
+    assert files, "native Parquet writer produced no file"
     table = pq.read_table(files[0]).to_pydict()
     assert len(table["group_id"]) == 2
     assert table["channels"][0] == ["cpu", "mem"]
     assert sorted(table["values"]) == [[1.0, 5.0], [1.1, 5.5]]
+
+
+def test_beam_engine_fallback_to_agnostic_write(mimir_source, tmp_path):
+    # a sink without a native hook still runs under Beam via gather-and-call
+    out = tmp_path / "fallback.txt"
+    BeamEngine().run(mimir_source, [_FileSink(str(out))])
+
+    lines = out.read_text().splitlines()
+    assert lines == ["pod-a", "pod-a"]

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -1,0 +1,177 @@
+"""Knowledge-base tests — SignalRecord, SignalStore (write/query), and the
+signal_history HTTP contract kube-verdict consumes."""
+import pytest
+
+from kb import SignalRecord, SignalStore, create_app
+
+
+def _rec(entity, metric, ts, severity="warning", score=2.0, method="patchtst", **kw):
+    return SignalRecord(
+        entity_uid=entity, metric_name=metric, ts=ts,
+        severity=severity, score=score, method=method, **kw
+    )
+
+
+# --- SignalRecord ---------------------------------------------------------
+
+def test_signal_record_valid_and_text():
+    r = _rec("Pod/prod/api", "cpu_usage", 1000, horizon="short", n_points=64)
+    assert r.is_anomalous
+    assert "metric=cpu_usage" in r.to_text() and "horizon=short" in r.to_text()
+
+
+def test_signal_record_custom_text_preserved():
+    r = _rec("Pod/p/a", "mem", 0, text="custom narrative")
+    assert r.to_text() == "custom narrative"
+
+
+@pytest.mark.parametrize("bad", [
+    dict(entity_uid="", metric_name="m", ts=0, severity="warning", score=1.0, method="zscore"),
+    dict(entity_uid="e", metric_name="m", ts=1.0, severity="warning", score=1.0, method="zscore"),
+    dict(entity_uid="e", metric_name="m", ts=0, severity="boom", score=1.0, method="zscore"),
+    dict(entity_uid="e", metric_name="m", ts=0, severity="normal", score=1.0, method="zscore", horizon="year"),
+])
+def test_signal_record_validation(bad):
+    with pytest.raises(ValueError):
+        SignalRecord(**bad)
+
+
+def test_from_anomaly_result_duck_typed():
+    class AR:  # mimics kube-verdict AnomalyResult
+        entity_uid = "Pod/prod/api"
+        metric_name = "cpu_usage"
+        severity = "critical"
+        score = 3.4
+        method = "patchtst"
+        horizon = "medium"
+        n_points = 96
+        def to_text(self):
+            return "ar text"
+    r = SignalRecord.from_anomaly_result(AR(), ts=1234, labels={"ns": "prod"})
+    assert r.severity == "critical" and r.ts == 1234 and r.labels == {"ns": "prod"}
+    assert r.to_text() == "ar text"
+
+
+# --- SignalStore ----------------------------------------------------------
+
+def test_store_query_empty_returns_list(tmp_path):
+    store = SignalStore(str(tmp_path / "kb"))
+    assert store.query("Pod/prod/api") == []
+
+
+def test_store_write_then_query_by_entity(tmp_path):
+    store = SignalStore(str(tmp_path / "kb"))
+    store.write([
+        _rec("Pod/prod/api", "cpu_usage", 1000),
+        _rec("Pod/prod/api", "mem", 2000, severity="critical", score=3.5),
+        _rec("Pod/prod/db", "cpu_usage", 1500),
+    ])
+    api = store.query("Pod/prod/api")
+    assert [r.metric_name for r in api] == ["cpu_usage", "mem"]   # ordered by ts
+    assert {r.entity_uid for r in api} == {"Pod/prod/api"}
+
+
+def test_store_query_filters_metric_and_window(tmp_path):
+    store = SignalStore(str(tmp_path / "kb"))
+    store.write([
+        _rec("Pod/prod/api", "cpu_usage", 1000),
+        _rec("Pod/prod/api", "cpu_usage", 5000),
+        _rec("Pod/prod/api", "cpu_usage", 9000),
+        _rec("Pod/prod/api", "mem", 5000),
+    ])
+    by_metric = store.query("Pod/prod/api", metric="cpu_usage")
+    assert [r.ts for r in by_metric] == [1000, 5000, 9000]
+    windowed = store.query("Pod/prod/api", metric="cpu_usage", since=2000, until=8000)
+    assert [r.ts for r in windowed] == [5000]
+
+
+def test_store_write_empty_returns_none(tmp_path):
+    store = SignalStore(str(tmp_path / "kb"))
+    assert store.write([]) is None
+
+
+def test_store_query_limit(tmp_path):
+    store = SignalStore(str(tmp_path / "kb"))
+    store.write([_rec("Pod/p/a", "cpu", t) for t in (1000, 2000, 3000)])
+    assert [r.ts for r in store.query("Pod/p/a", limit=2)] == [1000, 2000]
+
+
+def test_store_query_across_partitions_and_labels(tmp_path):
+    store = SignalStore(str(tmp_path / "kb"))
+    store.write([_rec("Pod/p/a", "cpu", 1000, labels={"team": "x"})])
+    store.write([_rec("Pod/p/a", "cpu", 2000, labels={"team": "y"})])   # second partition
+    rows = store.query("Pod/p/a")
+    assert [r.ts for r in rows] == [1000, 2000]
+    assert rows[0].labels == {"team": "x"} and rows[1].labels == {"team": "y"}
+
+
+# --- HTTP contract --------------------------------------------------------
+
+def test_signal_history_endpoint(tmp_path):
+    from fastapi.testclient import TestClient
+
+    store = SignalStore(str(tmp_path / "kb"))
+    store.write([
+        _rec("Pod/prod/api", "cpu_usage", 1000, severity="warning"),
+        _rec("Pod/prod/api", "cpu_usage", 2000, severity="critical", score=3.1),
+    ])
+    client = TestClient(create_app(store))
+
+    assert client.get("/health").json() == {"status": "ok"}
+
+    resp = client.get("/api/v1/signals/history", params={"entity": "Pod/prod/api", "metric": "cpu_usage"})
+    body = resp.json()
+    assert resp.status_code == 200
+    assert body["count"] == 2
+    assert [s["severity"] for s in body["signals"]] == ["warning", "critical"]
+    assert body["signals"][0]["entity_uid"] == "Pod/prod/api"
+
+
+def test_signal_history_unknown_entity_empty(tmp_path):
+    from fastapi.testclient import TestClient
+
+    store = SignalStore(str(tmp_path / "kb"))
+    store.write([_rec("Pod/prod/api", "cpu", 1000)])
+    client = TestClient(create_app(store))
+    body = client.get("/api/v1/signals/history", params={"entity": "Pod/prod/nope"}).json()
+    assert body["count"] == 0 and body["signals"] == []
+
+
+# --- SPI sink façade (write path goes through the connector cycle) --------
+
+class _SignalSource:
+    """Engine-agnostic source yielding SignalRecords (duck-typed)."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def read(self):
+        return self._rows
+
+    def native_beam_read(self):
+        return None
+
+
+def test_signal_store_sink_registered_and_conforms():
+    import kb  # noqa: F401  (registers the sink)
+    from connectors import available, build
+    from connectors.conformance import assert_sink_contract
+
+    assert available()["signal-store"] == "sink"
+    sink = build("signal-store", root="/tmp/kb-x")
+    assert_sink_contract(sink)
+    assert sink.describe()["root"] == "/tmp/kb-x"
+
+
+def test_signal_store_sink_full_spi_cycle(tmp_path):
+    import kb  # noqa: F401
+    from connectors import LocalEngine, build
+
+    sink = build("signal-store", root=str(tmp_path / "kb"))
+    rows = [_rec("Pod/p/a", "cpu", 1000), _rec("Pod/p/a", "cpu", 2000)]
+
+    # build → Engine.run → sink.write — the SPI cycle, no standalone write
+    LocalEngine().run(_SignalSource(rows), [sink])
+
+    out = sink.store.query("Pod/p/a")
+    assert [r.ts for r in out] == [1000, 2000]

--- a/tests/test_patchtst.py
+++ b/tests/test_patchtst.py
@@ -1,0 +1,53 @@
+"""PatchTSTDetector tests — fallback path (no torch needed) and the real
+forecast-residual path (guarded by torch/transformers, tiny config for speed)."""
+import pytest
+
+from detection import PatchTSTDetector
+from detection.detector import ZScoreDetector
+
+
+def _tiny() -> PatchTSTDetector:
+    # tiny config keeps the trained model fast in tests
+    return PatchTSTDetector(
+        context_length=16, patch_length=4, prediction_length=4,
+        d_model=8, num_heads=2, num_layers=1, epochs=2,
+    )
+
+
+def test_patchtst_short_series_falls_back_to_zscore():
+    r = _tiny().detect("e", "cpu", [1.0, 2.0, 3.0], ts=5)
+    assert r.method == "zscore" and r.severity == "normal" and r.n_points == 3
+
+
+def test_patchtst_is_detector_with_zscore_fallback():
+    assert PatchTSTDetector.method == "patchtst"
+    assert isinstance(_tiny().fallback, ZScoreDetector)
+
+
+def test_patchtst_severity_thresholds():
+    d = PatchTSTDetector(warning=1.8, critical=3.0)
+    assert d._severity(3.5) == "critical"
+    assert d._severity(2.0) == "warning"
+    assert d._severity(0.5) == "normal"
+
+
+def test_patchtst_path_produces_signal():
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    import numpy as np
+
+    vals = (10 + np.sin(np.linspace(0, 12, 60))).tolist()
+    r = _tiny().detect("Pod/p/a", "cpu", vals, ts=1700000000000)
+
+    assert r.method == "patchtst"
+    assert r.n_points == 60 and r.ts == 1700000000000
+    assert r.score >= 0.0 and r.severity in ("normal", "warning", "critical")
+
+
+def test_patchtst_too_few_training_windows_falls_back():
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    # len 22 >= context+pred (20) so it enters the PatchTST path, but the 80%
+    # train split (17) yields no full training window -> z-score fallback.
+    r = _tiny().detect("e", "cpu", [10.0] * 22, ts=1)
+    assert r.method == "zscore"

--- a/tests/test_reconstruction.py
+++ b/tests/test_reconstruction.py
@@ -1,0 +1,43 @@
+"""ReconstructionDetector tests — fallback path (no torch) and the real
+masked-reconstruction path (guarded by torch/transformers, tiny config)."""
+import pytest
+
+from detection import ReconstructionDetector
+from detection.detector import ZScoreDetector
+
+
+def _tiny() -> ReconstructionDetector:
+    return ReconstructionDetector(
+        context_length=16, patch_length=4, d_model=8,
+        num_heads=2, num_layers=1, epochs=2,
+    )
+
+
+def test_recon_short_series_falls_back_to_zscore():
+    r = _tiny().detect("e", "cpu", [1.0, 2.0, 3.0], ts=5)
+    assert r.method == "zscore" and r.n_points == 3
+
+
+def test_recon_is_detector_with_zscore_fallback():
+    assert ReconstructionDetector.method == "patchtst-recon"
+    assert isinstance(_tiny().fallback, ZScoreDetector)
+
+
+def test_recon_severity_thresholds():
+    d = ReconstructionDetector(warning=1.8, critical=3.0)
+    assert d._severity(3.1) == "critical"
+    assert d._severity(2.0) == "warning"
+    assert d._severity(0.9) == "normal"
+
+
+def test_recon_path_produces_signal():
+    pytest.importorskip("torch")
+    pytest.importorskip("transformers")
+    import numpy as np
+
+    vals = (10 + np.sin(np.linspace(0, 12, 60))).tolist()
+    r = _tiny().detect("Pod/p/a", "cpu", vals, ts=1700000000000)
+
+    assert r.method == "patchtst-recon"
+    assert r.n_points == 60 and r.ts == 1700000000000
+    assert r.score >= 0.0 and r.severity in ("normal", "warning", "critical")

--- a/tests/test_regime.py
+++ b/tests/test_regime.py
@@ -1,0 +1,99 @@
+"""RegimeSwitchDetector tests — deterministic state machine with stub
+detectors (no torch). Verifies which face runs, the NORMAL↔INCIDENT
+transitions, and the mode/regime annotations."""
+from detection import InMemoryRegimeState, RegimeSwitchDetector
+from detection.detector import Detector
+from kb.signal import SignalRecord
+
+
+class FakeDetector(Detector):
+    """Returns a preset severity sequence; records calls."""
+
+    def __init__(self, method, severities):
+        self.method = method
+        self.severities = list(severities)
+        self.calls = []
+        self._i = 0
+
+    def detect(self, entity_uid, metric_name, values, ts, labels=None):
+        self.calls.append((entity_uid, metric_name))
+        sev = self.severities[min(self._i, len(self.severities) - 1)]
+        self._i += 1
+        return SignalRecord(
+            entity_uid, metric_name, ts, sev, score=1.0,
+            method=self.method, labels=dict(labels or {}),
+        )
+
+
+def _detect(d, sev_label="cpu", ts=0):
+    return d.detect("Pod/p/a", sev_label, [0.0], ts)
+
+
+# --- state defaults -------------------------------------------------------
+
+def test_inmemory_regime_state_default_and_set():
+    st = InMemoryRegimeState()
+    assert st.get(("e", "m")) == "normal"
+    st.set(("e", "m"), "incident")
+    assert st.get(("e", "m")) == "incident"
+
+
+# --- the NORMAL ↔ INCIDENT cycle ------------------------------------------
+
+def test_regime_full_cycle():
+    fc = FakeDetector("patchtst", ["normal", "critical"])
+    dt = FakeDetector("patchtst-recon", ["critical", "normal"])
+    d = RegimeSwitchDetector(forecast=fc, detective=dt)
+
+    # tick1: NORMAL, forecast normal → stay NORMAL (anticipation)
+    s1 = _detect(d)
+    assert s1.method == "patchtst"
+    assert s1.labels["mode"] == "anticipation" and s1.labels["regime"] == "normal"
+
+    # tick2: NORMAL, forecast critical → break → INCIDENT
+    s2 = _detect(d)
+    assert s2.method == "patchtst"
+    assert s2.labels["mode"] == "anticipation" and s2.labels["regime"] == "incident"
+
+    # tick3: INCIDENT, reconstruction critical → stay INCIDENT (detective)
+    s3 = _detect(d)
+    assert s3.method == "patchtst-recon"
+    assert s3.labels["mode"] == "detective" and s3.labels["regime"] == "incident"
+
+    # tick4: INCIDENT, reconstruction normal → recovery → NORMAL
+    s4 = _detect(d)
+    assert s4.method == "patchtst-recon"
+    assert s4.labels["mode"] == "detective" and s4.labels["regime"] == "normal"
+
+    # forecast ran in NORMAL ticks, detective in INCIDENT ticks
+    assert len(fc.calls) == 2 and len(dt.calls) == 2
+
+
+def test_regime_warning_in_normal_stays_normal():
+    fc = FakeDetector("patchtst", ["warning"])
+    dt = FakeDetector("patchtst-recon", ["normal"])
+    d = RegimeSwitchDetector(forecast=fc, detective=dt)
+    s = _detect(d)
+    # an early WARN is anticipation, not a break — stay NORMAL
+    assert s.labels["regime"] == "normal" and s.labels["mode"] == "anticipation"
+    assert len(dt.calls) == 0
+
+
+def test_regime_warning_in_incident_stays_incident():
+    fc = FakeDetector("patchtst", ["critical"])
+    dt = FakeDetector("patchtst-recon", ["warning"])
+    d = RegimeSwitchDetector(forecast=fc, detective=dt)
+    _detect(d)               # → INCIDENT
+    s = _detect(d)           # INCIDENT, recon warning → stay INCIDENT
+    assert s.labels["regime"] == "incident" and s.labels["mode"] == "detective"
+
+
+def test_regime_is_independent_per_entity_metric():
+    fc = FakeDetector("patchtst", ["critical", "normal"])
+    dt = FakeDetector("patchtst-recon", ["normal"])
+    d = RegimeSwitchDetector(forecast=fc, detective=dt)
+
+    a = d.detect("Pod/a", "cpu", [0.0], 0)      # → INCIDENT for (Pod/a, cpu)
+    b = d.detect("Pod/b", "cpu", [0.0], 0)      # independent key, still NORMAL
+    assert a.labels["regime"] == "incident"
+    assert b.labels["regime"] == "normal"


### PR DESCRIPTION
## M1 — PatchTST inference engine

Decouples PatchTST from the training `Learner`: a checkpoint-backed engine exposing the model's **two heads** as plain methods — `forecast(window)` and `reconstruct(window)` — with RevIN normalization and the checkpoint loaded **once per process** (per Beam worker, later). No optimizer, no dataloader, no training.

### What's here
- **`inference/config.py`** — `ModelSpec`: architecture spec to rebuild a checkpoint (`num_patch` helper, `from_dict`). Native multivariate (D4).
- **`inference/engine.py`** — `PatchTSTInference.from_checkpoints` loads **two independent `PatchTST` instances**: forecast = prediction head (finetune), reconstruct = pretrain head (self-supervised). Their backbones diverge during finetune, so they are deliberately *not* a shared backbone.
  - `forecast(window[, future])` → RevIN-denormalized prediction; residual + per-channel RMSE when the realized horizon is given.
  - `reconstruct(window)` → patched reconstruction + per-channel error (normalized space, scale-invariant).
  - `torch` and the vendored `PatchTST_self_supervised` model are imported lazily.
- **`tests/test_inference.py`** — synthetic-checkpoint suite: round-trip save/load, both heads' shapes (single & batched), forecast RMSE, RevIN invariance, **load-once** (loader call count), partial-load warning, input validation. `inference/` added to the coverage gate — **100%**.
- **`requirements-inference.txt`** — `torch` + `numpy` only (no `transformers`).

### Design notes
- **Two checkpoints, two backbones.** Full finetune diverges the encoder from the pretrain encoder, so a single "shared backbone + two heads" would misrepresent the weights. Two instances is faithful and load-once still holds.
- **Reconstruction error in normalized space** — the right unit for an anomaly score.

### Scope / follow-ups
- Engine validated on **synthetic checkpoints**; real trained checkpoints (pretrain → finetune) + inference doc are a follow-up.
- Rebranching the D1 detectors onto this engine (dropping training-on-the-fly) is a separate PR.
- Unblocks the **M3** Beam `ModelHandler`, which reuses this engine for per-worker load.

### Tests
`pytest` — 88 passed, 100% coverage on measured packages.